### PR TITLE
Add script to generate the release notes file

### DIFF
--- a/release_tools/notes.py
+++ b/release_tools/notes.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2019 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+"""
+Script to generate the release notes of a package.
+
+It will read the changelog entries stored under 'releases/unreleased'
+directory and will generate a file with the list of changes.
+The script needs the name of the package and the version to release.
+"""
+
+import datetime
+import os
+import sys
+import textwrap
+
+import click
+
+from release_tools.entry import (CategoryChange,
+                                 determine_changelog_entries_dirpath,
+                                 read_changelog_entries)
+from release_tools.repo import GitHandler
+
+
+def validate_argument(ctx, param, value):
+    """Check argument valid values."""
+
+    value = value.strip("\n\r ")
+
+    if not value:
+        raise click.BadParameter("cannot be empty")
+    return value
+
+
+@click.command()
+@click.option('--dry-run', is_flag=True,
+              help="Do not write release notes file. Print to the standard output instead.")
+@click.option('--overwrite', is_flag=True,
+              help="Force to replace an existing release notes entry.")
+@click.argument('name', callback=validate_argument)
+@click.argument('version', callback=validate_argument)
+def notes(name, version, dry_run, overwrite):
+    """Generate release notes.
+
+    When you run this script, it will generate the release notes of the
+    package tracked by the current Git repository.
+
+    You will need to provide the 'NAME' of the package and the 'VERSION'
+    of the new release. The script will generate a Markdown document
+    under the 'releases' directory. Take into account the argument `NAME`
+    is only used as the title of the document.
+
+    In the case a release notes file for the same version already exists,
+    an error will be raised. Use '--overwrite' to force to replace the
+    existing file. If you just want to see the final result of the notes
+    but not generate a new file, please activate '--dry-run' flag.
+
+    NAME: title of the package for the release notes.
+
+    VERSION: version of the new release.
+    """
+    entry_list = read_unreleased_changelog_entries()
+
+    md = compose_release_notes(name, version, entry_list)
+
+    if dry_run:
+        click.echo(md)
+    else:
+        write_release_notes(version, md, overwrite=overwrite)
+
+
+def read_unreleased_changelog_entries():
+    """Import changelog entries to include in the notes."""
+
+    dirpath = determine_changelog_entries_dirpath()
+
+    if not os.path.exists(dirpath):
+        msg = "changelog entries directory '{}' does not exist.".format(dirpath)
+        raise click.ClickException(msg)
+
+    try:
+        entries = read_changelog_entries(dirpath)
+    except Exception as exc:
+        raise click.ClickException(exc)
+
+    entries = organize_entries_by_category(entries)
+
+    return entries
+
+
+def organize_entries_by_category(entry_list):
+    """Sort entries by category."""
+
+    entries = {}
+
+    for _, entry in entry_list.items():
+        entries.setdefault(entry.category.value, []).append(entry)
+
+    return entries
+
+
+def compose_release_notes(title, version, entries):
+    """Generate the release notes content."""
+
+    composer = ReleaseNotesComposer()
+    content = composer.compose(title, version, entries)
+    return content
+
+
+def write_release_notes(version, content, overwrite=False):
+    """Write the release notes text to a file."""
+
+    if not content:
+        msg = "Aborting due to empty release notes"
+        raise click.ClickException(msg)
+
+    mode = 'w' if overwrite else 'x'
+
+    filepath = determine_release_notes_filepath(version)
+
+    try:
+        filename = os.path.basename(filepath)
+
+        with open(filepath, mode=mode) as f:
+            f.write(content)
+    except FileExistsError:
+        msg = ("Release notes for version {} already exist. "
+               "Use '--overwrite' to replace it.").format(version)
+        raise click.ClickException(msg)
+    else:
+        click.echo("Release notes file '{}' created".format(filename))
+
+    return filepath
+
+
+def determine_release_notes_filepath(version):
+    """Determine the file path for the release notes."""
+
+    dirpath = GitHandler().root_path
+    dirpath = os.path.join(dirpath, 'releases')
+    filepath = os.path.join(dirpath, version + '.md')
+
+    return filepath
+
+
+class ReleaseNotesComposer:
+    """Markdown release notes composer."""
+
+    HEADLINE_TEMPLATE = "## {title} {version} - ({date})\n\n"
+    CATEGORY_TITLE_TEMPLATE = "**{title}:**\n\n"
+    ENTRY_DESC_PR_TEMPLATE = " * {desc} (#{pr})"
+    ENTRY_DESC_NO_PR_TEMPLATE = " * {desc}"
+    NOTES_INDENT = "   "
+    EMPTY_NOTES_TEMPLATE = "No changes list available.\n"
+
+    def compose(self, title, version, entries):
+        """Generate release notes using markdown format."""
+
+        headline = self._compose_headline(title, version)
+        sections = []
+
+        for category in CategoryChange:
+            sublist = entries.get(category.value, None)
+
+            if not sublist:
+                continue
+
+            sections.append(self._compose_category_section(category,
+                                                           sublist))
+
+        if sections:
+            content = headline + "\n".join(sections)
+        else:
+            content = headline + self.EMPTY_NOTES_TEMPLATE
+
+        content += '\n'
+
+        return content
+
+    def _compose_headline(self, title, version):
+        """Generate the headline of the document."""
+
+        metadata = {
+            'title': title,
+            'version': version,
+            'date': self._datetime_utcnow_str()
+        }
+
+        return self.HEADLINE_TEMPLATE.format(**metadata)
+
+    def _compose_category_section(self, category, entries):
+        """Generate a section with the entries of a given category."""
+
+        header = self._compose_category_title(category)
+        section = [
+            self._compose_entry(entry)
+            for entry in self._sort_entries_by_id(entries)
+        ]
+        content = header + "".join(section)
+
+        return content
+
+    def _compose_category_title(self, category):
+        """Generate the category title for a section."""
+
+        suffix = 's' if not category.title.endswith('x') else 'es'
+        title = category.title + suffix
+
+        return self.CATEGORY_TITLE_TEMPLATE.format(title=title)
+
+    def _compose_entry(self, entry):
+        """Generate the changelog entry text."""
+
+        if entry.pr:
+            content = self.ENTRY_DESC_PR_TEMPLATE.format(desc=entry.title,
+                                                         pr=entry.pr)
+        else:
+            content = self.ENTRY_DESC_NO_PR_TEMPLATE.format(desc=entry.title)
+
+        if entry.notes:
+            notes_text = textwrap.indent(textwrap.fill(entry.notes),
+                                         self.NOTES_INDENT)
+            content += "\\\n" + notes_text
+
+        content += "\n"
+
+        return content
+
+    @staticmethod
+    def _datetime_utcnow_str():
+        """Get a formatted string of the current datetime."""
+
+        return datetime.datetime.utcnow().strftime("%Y-%m-%d")
+
+    @staticmethod
+    def _sort_entries_by_id(entries):
+        """Order entries by PR identifier."""
+
+        # Entries with empty PR will be pushed to the end of the list
+        return sorted(entries, key=lambda e: int(e.pr) if e.pr else sys.maxsize)
+
+
+if __name__ == "__main__":
+    notes()

--- a/setup.py
+++ b/setup.py
@@ -40,5 +40,6 @@ setup(name="release-tools",
           [console_scripts]
           changelog=release_tools.changelog:changelog
           semverup=release_tools.semverup:semverup
+          notes=release_tools.notes:notes
       """,
       zip_safe=False)

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2019 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>..
+#
+# Authors:
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+import os
+import unittest
+import unittest.mock
+
+import click.testing
+
+from release_tools.notes import notes
+from release_tools.entry import CategoryChange
+
+
+RELEASE_NOTES_CONTENT = """## release-tools 0.8.10 - (2019-01-01)
+
+**New features:**
+
+ * first feature (#1)\\
+   Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+   eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+   minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+   aliquip ex ea commodo consequat. Duis aute irure dolor in
+   reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+   pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+   culpa qui officia deserunt mollit anim id est laborum.
+ * second feature (#3)
+ * final feature
+
+**Bug fixes:**
+
+ * first bug fix (#2)
+ * another fix\\
+   Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+   eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+   minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+   aliquip ex ea commodo consequat. Duis aute irure dolor in
+   reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+   pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+   culpa qui officia deserunt mollit anim id est laborum.
+
+"""
+RELEASE_NOTES_EMPTY = """## release-tools 0.8.10 - (2019-01-01)
+
+No changes list available.
+
+"""
+RELEASE_NOTES_FILE_ALREADY_EXISTS_ERROR = (
+    "Error: Release notes for version 0.8.10 already exist. Use '--overwrite' to replace it."
+)
+EMPTY_CONTENT_ERROR = (
+    "Error: Aborting due to empty release notes"
+)
+INVALID_CHANGELOG_ENTRY_ERROR = (
+    "Error: Invalid changelog entry format"
+)
+CHANGELOG_DIR_NOT_FOUND_ERROR = (
+    r"Error: changelog entries directory '.+' does not exist"
+)
+INVALID_NAME_ERROR = (
+    "Error: Invalid value for \"NAME\": cannot be empty"
+)
+INVALID_VERSION_ERROR = (
+    "Error: Invalid value for \"VERSION\": cannot be empty"
+)
+
+
+class TestNotes(unittest.TestCase):
+    """Unit tests for notes script"""
+
+    @staticmethod
+    def setup_unreleased_entries(dirpath):
+        """Set up a set of unreleased entry files"""
+
+        titles = [
+            "first feature",
+            "first bug fix",
+            "second feature",
+            "final feature",
+            "another fix",
+        ]
+        categories = [
+            CategoryChange.ADDED,
+            CategoryChange.FIXED,
+            CategoryChange.ADDED,
+            CategoryChange.ADDED,
+            CategoryChange.FIXED,
+        ]
+        authors = ['jsmith', 'jdoe', 'jsmith', 'jdoe', 'jsmith']
+        prs = [1, 2, 3, 'null', 'null']
+        notes = [True, False, False, False, True]
+        notes_txt = (
+            ">\n"
+            "  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor"
+            " incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,"
+            " quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo"
+            " consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse\n"
+            "  cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat"
+            " non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."
+        )
+
+        os.makedirs(dirpath)
+
+        # Create some entries
+        for x in range(0, 5):
+            filepath = os.path.join(dirpath, str(x) + '.yml')
+
+            with open(filepath, mode='w') as fd:
+                msg = "---\ntitle: {}\ncategory: {}\n"
+                msg += "author: {}\npull_request: {}\nnotes: {}\n"
+                ntxt = notes_txt if notes[x] else "null"
+                msg = msg.format(titles[x], categories[x].category, authors[x],
+                                 prs[x], ntxt)
+                fd.write(msg)
+
+    @unittest.mock.patch('release_tools.notes.ReleaseNotesComposer._datetime_utcnow_str')
+    @unittest.mock.patch('release_tools.notes.determine_changelog_entries_dirpath')
+    def test_release_notes(self, mock_dirpath, mock_utcnow):
+        """Check it it generates a release notes file"""
+
+        mock_utcnow.return_value = "2019-01-01"
+
+        runner = click.testing.CliRunner(mix_stderr=False)
+
+        with runner.isolated_filesystem() as fs:
+            dirpath = os.path.join(fs, 'releases', 'unreleased')
+            mock_dirpath.return_value = dirpath
+
+            self.setup_unreleased_entries(dirpath)
+
+            # Run the script command
+            result = runner.invoke(notes, ['release-tools', '0.8.10'])
+            self.assertEqual(result.exit_code, 0)
+
+            filepath = os.path.join(fs, 'releases', '0.8.10.md')
+            with open(filepath, 'r') as fd:
+                text = fd.read()
+
+            self.assertEqual(text, RELEASE_NOTES_CONTENT)
+
+    @unittest.mock.patch('release_tools.notes.ReleaseNotesComposer._datetime_utcnow_str')
+    @unittest.mock.patch('release_tools.notes.determine_changelog_entries_dirpath')
+    def test_dry_run(self, mock_dirpath, mock_utcnow):
+        """Check it it composes the release notes but does not create a file"""
+
+        mock_utcnow.return_value = "2019-01-01"
+
+        runner = click.testing.CliRunner(mix_stderr=False)
+
+        with runner.isolated_filesystem() as fs:
+            dirpath = os.path.join(fs, 'releases', 'unreleased')
+            mock_dirpath.return_value = dirpath
+
+            self.setup_unreleased_entries(dirpath)
+
+            # Run the script command
+            result = runner.invoke(notes, ['--dry-run', 'release-tools', '0.8.10'])
+            self.assertEqual(result.exit_code, 0)
+
+            filepath = os.path.join(fs, 'releases', '0.8.10.md')
+            self.assertEqual(os.path.exists(filepath), False)
+
+            self.assertEqual(result.stdout, RELEASE_NOTES_CONTENT + '\n')
+
+    @unittest.mock.patch('release_tools.notes.ReleaseNotesComposer._datetime_utcnow_str')
+    @unittest.mock.patch('release_tools.notes.determine_changelog_entries_dirpath')
+    def test_release_notes_no_entry_files(self, mock_dirpath, mock_utcnow):
+        """Check it it generates a release notes file when there are not entry files"""
+
+        mock_utcnow.return_value = "2019-01-01"
+
+        runner = click.testing.CliRunner(mix_stderr=False)
+
+        with runner.isolated_filesystem() as fs:
+            dirpath = os.path.join(fs, 'releases', 'unreleased')
+            os.makedirs(dirpath)
+            mock_dirpath.return_value = dirpath
+
+            # Run the script command
+            result = runner.invoke(notes, ['release-tools', '0.8.10'])
+            self.assertEqual(result.exit_code, 0)
+
+            filepath = os.path.join(fs, 'releases', '0.8.10.md')
+            with open(filepath, 'r') as fd:
+                text = fd.read()
+
+            self.assertEqual(text, RELEASE_NOTES_EMPTY)
+
+    @unittest.mock.patch('release_tools.notes.ReleaseNotesComposer._datetime_utcnow_str')
+    @unittest.mock.patch('release_tools.notes.determine_changelog_entries_dirpath')
+    def test_release_notes_file_is_not_overwritten(self, mock_dirpath, mock_utcnow):
+        """Check whether an existing release notes file is not replaced"""
+
+        mock_utcnow.return_value = "2019-01-01"
+
+        runner = click.testing.CliRunner(mix_stderr=False)
+
+        with runner.isolated_filesystem() as fs:
+            dirpath = os.path.join(fs, 'releases', 'unreleased')
+            mock_dirpath.return_value = dirpath
+
+            self.setup_unreleased_entries(dirpath)
+
+            # Create a file first
+            result = runner.invoke(notes, ['release-tools', '0.8.10'])
+            self.assertEqual(result.exit_code, 0)
+
+            # Try to replace it with an empty version
+            for filename in os.listdir(dirpath):
+                filepath = os.path.join(dirpath, filename)
+                os.remove(filepath)
+
+            result = runner.invoke(notes, ['release-tools', '0.8.10'])
+            self.assertEqual(result.exit_code, 1)
+
+            lines = result.stderr.split('\n')
+            self.assertEqual(lines[-2], RELEASE_NOTES_FILE_ALREADY_EXISTS_ERROR)
+
+            # The file did not change
+            filepath = os.path.join(fs, 'releases', '0.8.10.md')
+            with open(filepath, 'r') as fd:
+                text = fd.read()
+
+            self.assertEqual(text, RELEASE_NOTES_CONTENT)
+
+    @unittest.mock.patch('release_tools.notes.ReleaseNotesComposer._datetime_utcnow_str')
+    @unittest.mock.patch('release_tools.notes.determine_changelog_entries_dirpath')
+    def test_overwrite_release_notes_file(self, mock_dirpath, mock_utcnow):
+        """Check whether an existing release notes file is not replaced"""
+
+        mock_utcnow.return_value = "2019-01-01"
+
+        runner = click.testing.CliRunner(mix_stderr=False)
+
+        with runner.isolated_filesystem() as fs:
+            dirpath = os.path.join(fs, 'releases', 'unreleased')
+            mock_dirpath.return_value = dirpath
+
+            self.setup_unreleased_entries(dirpath)
+
+            # Create a file first
+            result = runner.invoke(notes, ['release-tools', '0.8.10'])
+            self.assertEqual(result.exit_code, 0)
+
+            # Try to replace it with an empty version
+            for filename in os.listdir(dirpath):
+                filepath = os.path.join(dirpath, filename)
+                os.remove(filepath)
+
+            result = runner.invoke(notes, ['--overwrite', 'release-tools', '0.8.10'])
+            self.assertEqual(result.exit_code, 0)
+
+            filepath = os.path.join(fs, 'releases', '0.8.10.md')
+            with open(filepath, 'r') as fd:
+                text = fd.read()
+
+            self.assertEqual(text, RELEASE_NOTES_EMPTY)
+
+    @unittest.mock.patch('release_tools.notes.compose_release_notes')
+    @unittest.mock.patch('release_tools.notes.determine_changelog_entries_dirpath')
+    def test_abort_empty_notes(self, mock_dirpath, mock_compose):
+        """Check if it stops the process when the content of release notes is empty"""
+
+        runner = click.testing.CliRunner(mix_stderr=False)
+
+        with runner.isolated_filesystem() as fs:
+            dirpath = os.path.join(fs, 'releases', 'unreleased')
+            mock_dirpath.return_value = dirpath
+
+            self.setup_unreleased_entries(dirpath)
+
+            # Force to return an empty content
+            mock_compose.return_value = ""
+
+            result = runner.invoke(notes, ['release-tools', '0.8.10'])
+            self.assertEqual(result.exit_code, 1)
+
+            lines = result.stderr.split('\n')
+            self.assertEqual(lines[-2], EMPTY_CONTENT_ERROR)
+
+    @unittest.mock.patch('release_tools.notes.read_changelog_entries')
+    @unittest.mock.patch('release_tools.notes.determine_changelog_entries_dirpath')
+    def test_error_reading_entries(self, mock_dirpath, mock_read_entries):
+        """Check if it stops the process when there is an error reading changelog entries"""
+
+        runner = click.testing.CliRunner(mix_stderr=False)
+
+        with runner.isolated_filesystem() as fs:
+            dirpath = os.path.join(fs, 'releases', 'unreleased')
+            mock_dirpath.return_value = dirpath
+
+            self.setup_unreleased_entries(dirpath)
+
+            # Force to return an error when reading the entries
+            mock_read_entries.side_effect = Exception("Invalid changelog entry format")
+
+            result = runner.invoke(notes, ['release-tools', '0.8.10'])
+            self.assertEqual(result.exit_code, 1)
+
+            lines = result.stderr.split('\n')
+            self.assertEqual(lines[-2], INVALID_CHANGELOG_ENTRY_ERROR)
+
+    @unittest.mock.patch('release_tools.notes.determine_changelog_entries_dirpath')
+    def test_changelog_dir_not_exists_error(self, mock_dirpath):
+        """Check if it returns an error when the changelog dir does not exist"""
+
+        runner = click.testing.CliRunner(mix_stderr=False)
+
+        with runner.isolated_filesystem() as fs:
+            dirpath = os.path.join(fs, 'releases', 'unreleased')
+            mock_dirpath.return_value = dirpath
+
+            # Run the script command
+            result = runner.invoke(notes, ['release-tools', '0.8.10'])
+            self.assertEqual(result.exit_code, 1)
+
+            lines = result.stderr.split('\n')
+            self.assertRegex(lines[-2], CHANGELOG_DIR_NOT_FOUND_ERROR)
+
+    def test_invalid_name(self):
+        """Check whether name argument is validated correctly"""
+
+        runner = click.testing.CliRunner(mix_stderr=False)
+
+        # Empty titles are not allowed
+        result = runner.invoke(notes, [''])
+        self.assertEqual(result.exit_code, 2)
+
+        lines = result.stderr.split('\n')
+        self.assertEqual(lines[-2], INVALID_NAME_ERROR)
+
+        # Only whitespaces are not allowed
+        result = runner.invoke(notes, [' '])
+        self.assertEqual(result.exit_code, 2)
+
+        lines = result.stderr.split('\n')
+        self.assertEqual(lines[-2], INVALID_NAME_ERROR)
+
+        # Only control characters are not allowed
+        result = runner.invoke(notes, ['\n\r\n'])
+        self.assertEqual(result.exit_code, 2)
+        self.assertEqual(lines[-2], INVALID_NAME_ERROR)
+
+    def test_invalid_version(self):
+        """Check whether version argument is validated correctly"""
+
+        runner = click.testing.CliRunner(mix_stderr=False)
+
+        # Empty titles are not allowed
+        result = runner.invoke(notes, ['release-tools', ''])
+        self.assertEqual(result.exit_code, 2)
+
+        lines = result.stderr.split('\n')
+        self.assertEqual(lines[-2], INVALID_VERSION_ERROR)
+
+        # Only whitespaces are not allowed
+        result = runner.invoke(notes, ['release-tools', ' '])
+        self.assertEqual(result.exit_code, 2)
+
+        lines = result.stderr.split('\n')
+        self.assertEqual(lines[-2], INVALID_VERSION_ERROR)
+
+        # Only control characters are not allowed
+        result = runner.invoke(notes, ['release-tools', '\n\r\n'])
+        self.assertEqual(result.exit_code, 2)
+        self.assertEqual(lines[-2], INVALID_VERSION_ERROR)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This script will read the changelog entries stored under 'releases/unreleased' directory and will generate a file with the list of changes. The script needs the name of the package and the version to release.