### PR TITLE
Automate version updates in pyproject file

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -22,8 +22,16 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "2.9.1"
 
+[[package]]
+category = "main"
+description = "Style preserving TOML library"
+name = "tomlkit"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "0.5.8"
+
 [metadata]
-content-hash = "fa2fe43b71a8a89d63ed79c74cac4b4b17c3ac5bcf10e7dbb16b113a1bde7e59"
+content-hash = "edb23c3242d3acca2298c39ce3e98ecff18550d0816b994bbc78742c1294ea2a"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -47,4 +55,8 @@ pyyaml = [
 semver = [
     {file = "semver-2.9.1-py2.py3-none-any.whl", hash = "sha256:095c3cba6d5433f21451101463b22cf831fe6996fcc8a603407fd8bea54f116b"},
     {file = "semver-2.9.1.tar.gz", hash = "sha256:723be40c74b6468861e0e3dbb80a41fc3b171a2a45bf956c245304773dc06055"},
+]
+tomlkit = [
+    {file = "tomlkit-0.5.8-py2.py3-none-any.whl", hash = "sha256:96e6369288571799a3052c1ef93b9de440e1ab751aa045f435b55e9d3bcd0690"},
+    {file = "tomlkit-0.5.8.tar.gz", hash = "sha256:32c10cc16ded7e4101c79f269910658cc2a0be5913f1252121c3cd603051c269"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ python = "^3.6"
 click = "^7.0"
 PyYAML = "^5.1.2"
 semver = "^2.9"
+tomlkit = "^0.5.8"
 
 [tool.poetry.dev-dependencies]
 

--- a/release_tools/publish.py
+++ b/release_tools/publish.py
@@ -104,6 +104,14 @@ def add_release_files(project, version):
 
     project.repo.add(version_file)
 
+    # Add pyproject.toml file
+    pyproject_file = project.pyproject_file
+
+    if not pyproject_file:
+        raise click.ClickException("pyproject file not found")
+
+    project.repo.add(pyproject_file)
+
     # Add release notes file
     notes_file = os.path.join(project.releases_path, version + '.md')
 

--- a/releases/unreleased/update-version-in-pyproject-file.yml
+++ b/releases/unreleased/update-version-in-pyproject-file.yml
@@ -1,0 +1,14 @@
+---
+title: Automate version updates in pyproject file
+category: added
+author: Santiago Dueñas <sduenas@bitergia.com>
+pull_request: null
+notes: >
+ Besides the file `_version.py`, there is another file
+ that stores the version number of the package. This file is
+ `pyproject.toml` and is used by `poetry` to generate Python
+ packages and source code tarballs. The command `semverup`
+ will also update this version number when called.
+
+ This file will also be part of the release commit generated
+ by `publish` command.

--- a/tests/test_semverup.py
+++ b/tests/test_semverup.py
@@ -26,6 +26,7 @@ import unittest
 import unittest.mock
 
 import click.testing
+import tomlkit.toml_file
 
 from release_tools import semverup
 from release_tools.entry import CategoryChange
@@ -43,6 +44,9 @@ VERSION_NUMBER_NOT_FOUND = (
 VERSION_NOT_UPDATED = (
     "Error: no changes found; version number not updated"
 )
+PYPROJECT_FILE_NOT_FOUND = (
+    "Error: pyproject file not found"
+)
 INVALID_VERSION_NUMBER = (
     r"Error: version number 'invalid format' in .+_version\.py is not a valid semver string"
 )
@@ -58,11 +62,26 @@ class TestSemVerUp(unittest.TestCase):
     """Unit tests for semverup script"""
 
     @staticmethod
+    def setup_files(version_file, project_file, version):
+        """Set up files needed for unit tests."""
+
+        TestSemVerUp.setup_version_file(version_file, version)
+        TestSemVerUp.setup_pyproject_file(project_file, version)
+
+    @staticmethod
     def setup_version_file(filepath, version):
         """Set up an initial version file with the given version number"""
 
         with open(filepath, mode='w') as fd:
-            fd.write("__version__ = \"{}\"".format(version))
+            fd.write("__version__ = \"{}\"\n".format(version))
+
+    @staticmethod
+    def setup_pyproject_file(filepath, version):
+        """Set up an initial version value in the pyproject file"""
+
+        with open(filepath, mode='w') as fd:
+            fd.write("[tool.poetry]\n")
+            fd.write("version = \"{}\"\n".format(version))
 
     @staticmethod
     def setup_unreleased_entries(dirpath, only_fixed=False):
@@ -99,13 +118,26 @@ class TestSemVerUp(unittest.TestCase):
 
     @staticmethod
     def read_version_number(filepath):
-        """Returns the version number stored in a file"""
+        """Returns the version number stored in a version file"""
 
         # Check version number
         with open(filepath, mode='r') as fd:
             version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
                                 fd.read(), re.MULTILINE).group(1)
         return version
+
+
+    @staticmethod
+    def read_version_number_from_pyproject(filepath):
+        """Returns the version number stored in a pyproject file"""
+
+        fd = tomlkit.toml_file.TOMLFile(filepath)
+
+        metadata = fd.read()
+        poetry_metadata = metadata["tool"]["poetry"]
+
+        return poetry_metadata["version"]
+
 
     @unittest.mock.patch('release_tools.semverup.Project')
     def test_version_is_updated(self, mock_project):
@@ -117,10 +149,13 @@ class TestSemVerUp(unittest.TestCase):
             version_file = os.path.join(fs, '_version.py')
             mock_project.return_value.version_file = version_file
 
+            project_file = os.path.join(fs, 'pyproject.toml')
+            mock_project.return_value.pyproject_file = project_file
+
             dirpath = os.path.join(fs, 'releases', 'unreleased')
             mock_project.return_value.unreleased_changes_path = dirpath
 
-            self.setup_version_file(version_file, "0.1.0")
+            self.setup_files(version_file, project_file, "0.1.0")
             self.setup_unreleased_entries(dirpath)
 
             # Run the script command
@@ -129,6 +164,9 @@ class TestSemVerUp(unittest.TestCase):
             self.assertEqual(result.stdout, "0.2.0\n")
 
             version = self.read_version_number(version_file)
+            self.assertEqual(version, "0.2.0")
+
+            version = self.read_version_number_from_pyproject(project_file)
             self.assertEqual(version, "0.2.0")
 
     @unittest.mock.patch('release_tools.semverup.Project')
@@ -141,10 +179,13 @@ class TestSemVerUp(unittest.TestCase):
             version_file = os.path.join(fs, '_version.py')
             mock_project.return_value.version_file = version_file
 
+            project_file = os.path.join(fs, 'pyproject.toml')
+            mock_project.return_value.pyproject_file = project_file
+
             dirpath = os.path.join(fs, 'releases', 'unreleased')
             mock_project.return_value.unreleased_changes_path = dirpath
 
-            self.setup_version_file(version_file, "0.8.10")
+            self.setup_files(version_file, project_file, "0.8.10")
             self.setup_unreleased_entries(dirpath)
 
             # Run the script command
@@ -154,6 +195,10 @@ class TestSemVerUp(unittest.TestCase):
 
             # Version number file did not change
             version = self.read_version_number(version_file)
+            self.assertEqual(version, "0.8.10")
+
+            # Pyproject version number did not change either
+            version = self.read_version_number_from_pyproject(project_file)
             self.assertEqual(version, "0.8.10")
 
     @unittest.mock.patch('release_tools.semverup.Project')
@@ -166,10 +211,13 @@ class TestSemVerUp(unittest.TestCase):
             version_file = os.path.join(fs, '_version.py')
             mock_project.return_value.version_file = version_file
 
+            project_file = os.path.join(fs, 'pyproject.toml')
+            mock_project.return_value.pyproject_file = project_file
+
             dirpath = os.path.join(fs, 'releases', 'unreleased')
             mock_project.return_value.unreleased_changes_path = dirpath
 
-            self.setup_version_file(version_file, "0.8.10")
+            self.setup_files(version_file, project_file, "0.8.10")
             self.setup_unreleased_entries(dirpath, only_fixed=True)
 
             # Run the script command
@@ -177,23 +225,30 @@ class TestSemVerUp(unittest.TestCase):
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(result.stdout, "0.8.11\n")
 
+            # Version changed in files
             version = self.read_version_number(version_file)
+            self.assertEqual(version, "0.8.11")
+
+            version = self.read_version_number_from_pyproject(project_file)
             self.assertEqual(version, "0.8.11")
 
     @unittest.mock.patch('release_tools.semverup.Project')
     def test_minor_number_is_bumped(self, mock_project):
         """Check whether the patch number is bumped when there are mixed changes"""
 
-        runner = click.testing.CliRunner()
+        runner = click.testing.CliRunner(mix_stderr=False)
 
         with runner.isolated_filesystem() as fs:
             version_file = os.path.join(fs, '_version.py')
             mock_project.return_value.version_file = version_file
 
+            project_file = os.path.join(fs, 'pyproject.toml')
+            mock_project.return_value.pyproject_file = project_file
+
             dirpath = os.path.join(fs, 'releases', 'unreleased')
             mock_project.return_value.unreleased_changes_path = dirpath
 
-            self.setup_version_file(version_file, "0.8.10")
+            self.setup_files(version_file, project_file, "0.8.10")
             self.setup_unreleased_entries(dirpath)
 
             # Run the script command
@@ -201,8 +256,11 @@ class TestSemVerUp(unittest.TestCase):
             self.assertEqual(result.exit_code, 0)
             self.assertEqual(result.stdout, "0.9.0\n")
 
-            # Check version number
+            # Version changed in files
             version = self.read_version_number(version_file)
+            self.assertEqual(version, "0.9.0")
+
+            version = self.read_version_number_from_pyproject(project_file)
             self.assertEqual(version, "0.9.0")
 
     @unittest.mock.patch('release_tools.semverup.Project')
@@ -215,10 +273,13 @@ class TestSemVerUp(unittest.TestCase):
             version_file = os.path.join(fs, '_version.py')
             mock_project.return_value.version_file = version_file
 
+            project_file = os.path.join(fs, 'pyproject.toml')
+            mock_project.return_value.pyproject_file = project_file
+
             dirpath = os.path.join(fs, 'releases', 'unreleased')
             mock_project.return_value.unreleased_changes_path = dirpath
 
-            self.setup_version_file(version_file, "0.8.10")
+            self.setup_files(version_file, project_file, "0.8.10")
 
             # Create an empty dir
             os.makedirs(dirpath)
@@ -234,6 +295,10 @@ class TestSemVerUp(unittest.TestCase):
             version = self.read_version_number(version_file)
             self.assertEqual(version, "0.8.10")
 
+            # Pyproject version number did not change either
+            version = self.read_version_number_from_pyproject(project_file)
+            self.assertEqual(version, "0.8.10")
+
     @unittest.mock.patch('release_tools.semverup.Project')
     def test_changelog_dir_not_exists_error(self, mock_project):
         """Check if it returns an error when the changelog dir does not exist"""
@@ -244,10 +309,13 @@ class TestSemVerUp(unittest.TestCase):
             version_file = os.path.join(fs, '_version.py')
             mock_project.return_value.version_file = version_file
 
+            project_file = os.path.join(fs, 'pyproject.toml')
+            mock_project.return_value.pyproject_file = project_file
+
             dirpath = os.path.join(fs, 'releases', 'unreleased')
             mock_project.return_value.unreleased_changes_path = dirpath
 
-            self.setup_version_file(version_file, "0.8.10")
+            self.setup_files(version_file, project_file, "0.8.10")
 
             # Run the script command
             result = runner.invoke(semverup.semverup)
@@ -260,6 +328,10 @@ class TestSemVerUp(unittest.TestCase):
             version = self.read_version_number(version_file)
             self.assertEqual(version, "0.8.10")
 
+            # Pyproject version number did not change either
+            version = self.read_version_number_from_pyproject(project_file)
+            self.assertEqual(version, "0.8.10")
+
     @unittest.mock.patch('release_tools.semverup.Project')
     def test_changelog_invalid_entry_error(self, mock_project):
         """Check if it returns an error when a changelog entry is invalid"""
@@ -270,10 +342,13 @@ class TestSemVerUp(unittest.TestCase):
             version_file = os.path.join(fs, '_version.py')
             mock_project.return_value.version_file = version_file
 
+            project_file = os.path.join(fs, 'pyproject.toml')
+            mock_project.return_value.pyproject_file = project_file
+
             dirpath = os.path.join(fs, 'releases', 'unreleased')
             mock_project.return_value.unreleased_changes_path = dirpath
 
-            self.setup_version_file(version_file, "0.8.10")
+            self.setup_files(version_file, project_file, "0.8.10")
             self.setup_unreleased_entries(dirpath)
 
             # Create an invalid entry
@@ -295,6 +370,10 @@ class TestSemVerUp(unittest.TestCase):
             version = self.read_version_number(version_file)
             self.assertEqual(version, "0.8.10")
 
+            # Pyproject version number did not change either
+            version = self.read_version_number_from_pyproject(project_file)
+            self.assertEqual(version, "0.8.10")
+
     @unittest.mock.patch('release_tools.semverup.Project')
     def test_version_file_not_found(self, mock_project):
         """Check whether it fails when the version file is not found"""
@@ -303,6 +382,9 @@ class TestSemVerUp(unittest.TestCase):
 
         with runner.isolated_filesystem() as fs:
             mock_project.return_value.version_file = None
+
+            project_file = os.path.join(fs, 'pyproject.toml')
+            mock_project.return_value.pyproject_file = project_file
 
             dirpath = os.path.join(fs, 'releases', 'unreleased')
             mock_project.return_value.unreleased_changes_path = dirpath
@@ -351,9 +433,9 @@ class TestSemVerUp(unittest.TestCase):
             dirpath = os.path.join(fs, 'releases', 'unreleased')
             mock_project.return_value.unreleased_changes_path = dirpath
 
-            # Write an invalid format
+            # Write an invalid content
             with open(version_file, mode='w') as fd:
-                fd.write("invalid format")
+                fd.write("lorem ipsum")
 
             self.setup_unreleased_entries(dirpath)
 
@@ -386,6 +468,31 @@ class TestSemVerUp(unittest.TestCase):
 
             lines = result.stderr.split('\n')
             self.assertRegex(lines[-2], INVALID_VERSION_NUMBER)
+
+    @unittest.mock.patch('release_tools.semverup.Project')
+    def test_pyproject_file_not_found(self, mock_project):
+        """Check whether it fails when the pyproject file is not found"""
+
+        runner = click.testing.CliRunner(mix_stderr=False)
+
+        with runner.isolated_filesystem() as fs:
+            version_file = os.path.join(fs, '_version.py')
+            mock_project.return_value.version_file = version_file
+
+            mock_project.return_value.pyproject_file = None
+
+            dirpath = os.path.join(fs, 'releases', 'unreleased')
+            mock_project.return_value.unreleased_changes_path = dirpath
+
+            self.setup_version_file(version_file, "0.8.10")
+            self.setup_unreleased_entries(dirpath)
+
+            # Run the script command
+            result = runner.invoke(semverup.semverup)
+            self.assertEqual(result.exit_code, 1)
+
+            lines = result.stderr.split('\n')
+            self.assertEqual(lines[-2], PYPROJECT_FILE_NOT_FOUND)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Besides the file `_version.py`, there is another file that stores the version number of the package. This file is `pyproject.toml` and is used by `poetry` to generate Python packages and source code tarballs.

With this PR `semverup` will also update this version number when called. Command `publish` will include the file within the release commit.

To test it, run `semverup` with some unreleased changes. You'll see both `_version.py` and `pyproject.toml` files have changed. Then, generate the release notes with `notes` and generate the release commit and tag calling `publish`. This command will commit the changes in `pyproject.toml`.