### PR TITLE
Update news file

### DIFF
--- a/release_tools/project.py
+++ b/release_tools/project.py
@@ -24,6 +24,7 @@ import os
 from release_tools.repo import GitHandler
 
 
+NEWS_FILENAME = 'NEWS'
 PYPROJECT_FILENAME = 'pyproject.toml'
 VERSION_FILENAME = '_version.py'
 
@@ -43,6 +44,12 @@ class Project:
         """Base path of the project."""
 
         return self._basepath
+
+    @property
+    def news_file(self):
+        """Path the the news file."""
+
+        return os.path.join(self.basepath, NEWS_FILENAME)
 
     @property
     def pyproject_file(self):

--- a/release_tools/publish.py
+++ b/release_tools/publish.py
@@ -121,6 +121,15 @@ def add_release_files(project, version):
 
     project.repo.add(notes_file)
 
+    # Add NEWS file
+    news_file = project.news_file
+
+    if not os.path.exists(news_file):
+        msg = "news file not found"
+        raise click.ClickException(msg)
+
+    project.repo.add(news_file)
+
     click.echo("done")
 
 

--- a/releases/unreleased/update-news-file-with-the-latest-relase-notes.yml
+++ b/releases/unreleased/update-news-file-with-the-latest-relase-notes.yml
@@ -1,0 +1,10 @@
+---
+title: Update NEWS file with the latest relase notes
+category: added
+author: Santiago Dueñas <sduenas@bitergia.com>
+pull_request: null
+notes: >
+  The command `notes` incorporates the new option `--news`.
+  This flag allows to add the contents of the notes generated
+  for the relase to the NEWS file. By default, NEWS file
+  will not be updated during the release.

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -64,6 +64,18 @@ class TestProject(unittest.TestCase):
         expected = "/tmp/repo/releases/unreleased"
         self.assertEqual(project.unreleased_changes_path, expected)
 
+    @unittest.mock.patch('release_tools.project.GitHandler.root_path',
+                         new_callable=unittest.mock.PropertyMock)
+    def test_news_file(self, mock_root_path):
+        """Check if the property returns the news file path"""
+
+        mock_root_path.return_value = "/tmp/repo/"
+
+        project = Project('/tmp/repo/')
+
+        expected = "/tmp/repo/NEWS"
+        self.assertEqual(project.news_file, expected)
+
     @unittest.mock.patch('release_tools.project.GitHandler.find_file')
     @unittest.mock.patch('release_tools.project.GitHandler.root_path',
                          new_callable=unittest.mock.PropertyMock)


### PR DESCRIPTION
This PR allows to update the NEWS file when new release notes are produced. To update it, use the parameter `--news` while running `notes` command.