### PR TITLE
Fix error in publish when unreleased directory does not exist

### DIFF
--- a/release_tools/publish.py
+++ b/release_tools/publish.py
@@ -92,6 +92,10 @@ def remove_unreleased_changelog_entries(project):
 
     dirpath = project.unreleased_changes_path
 
+    if not os.path.exists(dirpath):
+        msg = "changelog entries directory '{}' does not exist.".format(dirpath)
+        raise click.ClickException(msg)
+
     entries = read_changelog_entries(dirpath).keys()
 
     for filename in entries:

--- a/releases/unreleased/check-if-unreleased-dir-exists-when-publishing.yml
+++ b/releases/unreleased/check-if-unreleased-dir-exists-when-publishing.yml
@@ -1,0 +1,10 @@
+---
+title: Check if unreleased dir exists when publishing
+category: fixed
+author: Santiago Dueñas <sduenas@bitergia.com>
+issue: 5
+notes: >
+  An exception was raised when `publish` command was called
+  and `unreleased` directory did not exist. Now, instead of
+  raising an exception, `publish` command fails and displays
+  a message with the error.


### PR DESCRIPTION
An exception was raised when `publish` command was called and `unreleased` directory did not exist. Now, instead of raising an exception, `publish` command fails and displays a message with the error.

This PR fixes the error reported in #5.