### PR TITLE
Replace pr for issue field

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ defined in your system.
 title: 'Fix bug #666'
 category: fixed
 author: John Smith <jsmith@example.com>
-pull_request: null
+issue: 666
 notes: >
   The bug was making impossible to cast a spell on
   a magician.
@@ -299,7 +299,7 @@ of each block. See the next example:
 title: 'Example of notes'
 category: fixed
 author: John Smith <jsmith@example.com>
-pull_request: null
+issue: 1
 notes: >
   Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
   tempor incididunt ut labore et dolore magna aliqua.

--- a/release_tools/changelog.py
+++ b/release_tools/changelog.py
@@ -193,11 +193,11 @@ def check_changelog_entries_dir(project):
     return dirpath
 
 
-def create_changelog_entry_content(title, category, author=None, pr=None,
+def create_changelog_entry_content(title, category, author=None, issue=None,
                                    run_editor=True):
     """Generates the content of a changelog entry."""
 
-    entry = ChangelogEntry(title, category, author=author, pr=pr)
+    entry = ChangelogEntry(title, category, author=author, issue=issue)
     contents = entry.to_dict()
     stream = yaml.dump(contents, sort_keys=False,
                        explicit_start=True)

--- a/release_tools/entry.py
+++ b/release_tools/entry.py
@@ -68,12 +68,12 @@ class CategoryChange(enum.Enum):
 class ChangelogEntry:
     """Class to store changelog entries data."""
 
-    def __init__(self, title, category, author, pr=None, notes=None):
+    def __init__(self, title, category, author, issue=None, notes=None):
         self._category = None
         self.title = title
         self.category = category
         self.author = author
-        self.pr = pr
+        self.issue = issue
         self.notes = notes
 
     @property
@@ -89,7 +89,7 @@ class ChangelogEntry:
             'title': self.title,
             'category': self.category.category,
             'author': self.author,
-            'pull_request': self.pr,
+            'issue': self.issue,
             'notes': self.notes
         }
 
@@ -104,7 +104,7 @@ class ChangelogEntry:
             entry = cls(data['title'],
                         data['category'],
                         data['author'],
-                        pr=data['pull_request'],
+                        issue=data['issue'],
                         notes=data['notes'])
         except KeyError as exc:
             msg = "invalid format for {}; '{}' attribute not found".format(filepath,

--- a/release_tools/notes.py
+++ b/release_tools/notes.py
@@ -215,7 +215,7 @@ class ReleaseNotesComposer:
 
     HEADLINE_TEMPLATE = "## {title} {version} - ({date})\n\n"
     CATEGORY_TITLE_TEMPLATE = "**{title}:**\n\n"
-    ENTRY_DESC_PR_TEMPLATE = " * {desc} (#{pr})"
+    ENTRY_DESC_PR_TEMPLATE = " * {desc} (#{issue})"
     ENTRY_DESC_NO_PR_TEMPLATE = " * {desc}"
     NOTES_INDENT = "   "
     EMPTY_NOTES_TEMPLATE = "No changes list available.\n"
@@ -278,9 +278,9 @@ class ReleaseNotesComposer:
     def _compose_entry(self, entry):
         """Generate the changelog entry text."""
 
-        if entry.pr:
+        if entry.issue:
             content = self.ENTRY_DESC_PR_TEMPLATE.format(desc=entry.title,
-                                                         pr=entry.pr)
+                                                         issue=entry.issue)
         else:
             content = self.ENTRY_DESC_NO_PR_TEMPLATE.format(desc=entry.title)
 
@@ -301,10 +301,10 @@ class ReleaseNotesComposer:
 
     @staticmethod
     def _sort_entries_by_id(entries):
-        """Order entries by PR identifier."""
+        """Order entries by issue identifier."""
 
-        # Entries with empty PR will be pushed to the end of the list
-        return sorted(entries, key=lambda e: int(e.pr) if e.pr else sys.maxsize)
+        # Entries with empty issue will be pushed to the end of the list
+        return sorted(entries, key=lambda e: int(e.issue) if e.issue else sys.maxsize)
 
 
 if __name__ == "__main__":

--- a/releases/unreleased/push-release-only-with-only-push.yml
+++ b/releases/unreleased/push-release-only-with-only-push.yml
@@ -2,7 +2,7 @@
 title: Push release only with `publish`
 category: added
 author: Santiago Dueñas <sduenas@bitergia.com>
-pull_request: null
+issue: null
 notes: >
   The command `publish` generates the commit and tag
   release but by default it does not push them to a

--- a/releases/unreleased/replace-pull-request-field-for-issue-in-changelog-entries.yml
+++ b/releases/unreleased/replace-pull-request-field-for-issue-in-changelog-entries.yml
@@ -1,0 +1,17 @@
+---
+title: Replace pull request field for issue in changelog entries
+category: changed
+author: Santiago Dueñas <sduenas@bitergia.com>
+issue: 10
+notes: >
+  The initial idea of the pull request field in a changelog
+  entry was to know which PR introduced the change. The problem
+  is the reference is unknown until the PR is generated, so
+  developers will need to modify the entry and the PR later
+  to include the reference. Therefore, we considered it is
+  better to include a reference to an issue which is more
+  generic and can be known in advance.
+  
+  Take into account you will need to update your unreleased
+  changelog entries if you want to use this new version of
+  the tools.

--- a/releases/unreleased/update-news-file-with-the-latest-relase-notes.yml
+++ b/releases/unreleased/update-news-file-with-the-latest-relase-notes.yml
@@ -2,7 +2,7 @@
 title: Update NEWS file with the latest relase notes
 category: added
 author: Santiago Dueñas <sduenas@bitergia.com>
-pull_request: null
+issue: null
 notes: >
   The command `notes` incorporates the new option `--news`.
   This flag allows to add the contents of the notes generated

--- a/releases/unreleased/update-version-in-pyproject-file.yml
+++ b/releases/unreleased/update-version-in-pyproject-file.yml
@@ -2,7 +2,7 @@
 title: Automate version updates in pyproject file
 category: added
 author: Santiago Dueñas <sduenas@bitergia.com>
-pull_request: null
+issue: null
 notes: >
  Besides the file `_version.py`, there is another file
  that stores the version number of the package. This file is

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -80,7 +80,7 @@ class TestChangelog(unittest.TestCase):
                 self.assertEqual(entry['title'], 'new change')
                 self.assertEqual(entry['category'], 'added')
                 self.assertEqual(entry['author'], None)
-                self.assertEqual(entry['pull_request'], None)
+                self.assertEqual(entry['issue'], None)
                 self.assertEqual(entry['notes'], None)
 
     @unittest.mock.patch('release_tools.changelog.Project')
@@ -124,7 +124,7 @@ class TestChangelog(unittest.TestCase):
                 self.assertEqual(entry['title'], 'new change')
                 self.assertEqual(entry['category'], 'fixed')
                 self.assertEqual(entry['author'], None)
-                self.assertEqual(entry['pull_request'], None)
+                self.assertEqual(entry['issue'], None)
                 self.assertEqual(entry['notes'], None)
 
     @unittest.mock.patch('release_tools.changelog.Project')
@@ -156,7 +156,7 @@ class TestChangelog(unittest.TestCase):
                 self.assertEqual(entry['title'], 'new change')
                 self.assertEqual(entry['category'], 'fixed')
                 self.assertEqual(entry['author'], None)
-                self.assertEqual(entry['pull_request'], None)
+                self.assertEqual(entry['issue'], None)
                 self.assertEqual(entry['notes'], None)
 
             # Try to replace it
@@ -174,7 +174,7 @@ class TestChangelog(unittest.TestCase):
                 self.assertEqual(entry['title'], 'new change')
                 self.assertEqual(entry['category'], 'added')
                 self.assertEqual(entry['author'], None)
-                self.assertEqual(entry['pull_request'], None)
+                self.assertEqual(entry['issue'], None)
                 self.assertEqual(entry['notes'], None)
 
     @unittest.mock.patch('release_tools.changelog.Project')

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -82,15 +82,15 @@ class TestChangelogEntry(unittest.TestCase):
         self.assertEqual(entry.title, 'new entry')
         self.assertEqual(entry.category, CategoryChange.FIXED)
         self.assertEqual(entry.author, 'jdoe')
-        self.assertEqual(entry.pr, None)
+        self.assertEqual(entry.issue, None)
         self.assertEqual(entry.notes, None)
 
         entry = ChangelogEntry('last entry', 'added', 'jsmith',
-                               pr='42', notes="some notes go here")
+                               issue='42', notes="some notes go here")
         self.assertEqual(entry.title, 'last entry')
         self.assertEqual(entry.category, CategoryChange.ADDED)
         self.assertEqual(entry.author, 'jsmith')
-        self.assertEqual(entry.pr, '42')
+        self.assertEqual(entry.issue, '42')
         self.assertEqual(entry.notes, 'some notes go here')
 
     def test_to_dict(self):
@@ -100,12 +100,12 @@ class TestChangelogEntry(unittest.TestCase):
             'title': 'last entry',
             'category': 'added',
             'author': 'jsmith',
-            'pull_request': '42',
+            'issue': '42',
             'notes': 'some notes go here'
         }
 
         entry = ChangelogEntry('last entry', 'added', 'jsmith',
-                               pr='42', notes="some notes go here")
+                               issue='42', notes="some notes go here")
         self.assertDictEqual(entry.to_dict(), expected)
 
     def test_import_from_yaml_file(self):
@@ -113,14 +113,14 @@ class TestChangelogEntry(unittest.TestCase):
 
         with tempfile.NamedTemporaryFile() as f:
             f.write(b"---\ntitle: last entry\ncategory: added\n")
-            f.write(b"author: jsmith\npull_request: '42'\nnotes: 'some notes go here'\n")
+            f.write(b"author: jsmith\nissue: '42'\nnotes: 'some notes go here'\n")
             f.seek(0)
 
             expected = {
                 'title': 'last entry',
                 'category': 'added',
                 'author': 'jsmith',
-                'pull_request': '42',
+                'issue': '42',
                 'notes': 'some notes go here'
             }
 
@@ -133,7 +133,7 @@ class TestChangelogEntry(unittest.TestCase):
         with tempfile.NamedTemporaryFile() as f:
             # The tittle is missing on this file
             f.write(b"---category: added\n")
-            f.write(b"author: jsmith\npull_request: '42'\nnotes: 'some notes go here'\n")
+            f.write(b"author: jsmith\nissue: '42'\nnotes: 'some notes go here'\n")
             f.seek(0)
 
             with self.assertRaisesRegex(Exception, "'title' attribute not found"):
@@ -161,7 +161,7 @@ class TestReadChangelogEntries(unittest.TestCase):
 
                 with open(filepath, mode='w') as f:
                     msg = "---\ntitle: {}\ncategory: {}\n"
-                    msg += "author: {}\npull_request: '{}'\nnotes: null\n"
+                    msg += "author: {}\nissue: '{}'\nnotes: null\n"
                     msg = msg.format(titles[x], categories[x].category, authors[x], x)
                     f.write(msg)
 
@@ -179,21 +179,21 @@ class TestReadChangelogEntries(unittest.TestCase):
             self.assertEqual(entry.title, 'first change')
             self.assertEqual(entry.category, CategoryChange.ADDED)
             self.assertEqual(entry.author, 'jsmith')
-            self.assertEqual(entry.pr, '0')
+            self.assertEqual(entry.issue, '0')
             self.assertEqual(entry.notes, None)
 
             entry = entries['1.yml']
             self.assertEqual(entry.title, 'next change')
             self.assertEqual(entry.category, CategoryChange.FIXED)
             self.assertEqual(entry.author, 'jdoe')
-            self.assertEqual(entry.pr, '1')
+            self.assertEqual(entry.issue, '1')
             self.assertEqual(entry.notes, None)
 
             entry = entries['2.yml']
             self.assertEqual(entry.title, 'last change')
             self.assertEqual(entry.category, CategoryChange.DEPRECATED)
             self.assertEqual(entry.author, 'jsmith')
-            self.assertEqual(entry.pr, '2')
+            self.assertEqual(entry.issue, '2')
             self.assertEqual(entry.notes, None)
 
     def test_read_entries_empty_dir(self):

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -113,7 +113,7 @@ class TestNotes(unittest.TestCase):
             CategoryChange.FIXED,
         ]
         authors = ['jsmith', 'jdoe', 'jsmith', 'jdoe', 'jsmith']
-        prs = [1, 2, 3, 'null', 'null']
+        issues = [1, 2, 3, 'null', 'null']
         notes = [True, False, False, False, True]
         notes_txt = (
             ">\n"
@@ -133,10 +133,10 @@ class TestNotes(unittest.TestCase):
 
             with open(filepath, mode='w') as fd:
                 msg = "---\ntitle: {}\ncategory: {}\n"
-                msg += "author: {}\npull_request: {}\nnotes: {}\n"
+                msg += "author: {}\nissue: {}\nnotes: {}\n"
                 ntxt = notes_txt if notes[x] else "null"
                 msg = msg.format(titles[x], categories[x].category, authors[x],
-                                 prs[x], ntxt)
+                                 issues[x], ntxt)
                 fd.write(msg)
 
     @staticmethod

--- a/tests/test_semverup.py
+++ b/tests/test_semverup.py
@@ -112,7 +112,7 @@ class TestSemVerUp(unittest.TestCase):
 
             with open(filepath, mode='w') as fd:
                 msg = "---\ntitle: {}\ncategory: {}\n"
-                msg += "author: {}\npull_request: '{}'\nnotes: null\n"
+                msg += "author: {}\nissue: '{}'\nnotes: null\n"
                 msg = msg.format(titles[x], categories[x].category, authors[x], x)
                 fd.write(msg)
 
@@ -356,7 +356,7 @@ class TestSemVerUp(unittest.TestCase):
 
             with open(entry_fp, mode='w') as fd:
                 msg = "---category: added\n"
-                msg += "author: jsmith\npull_request: '42'\nnotes: 'some notes go here'\n"
+                msg += "author: jsmith\nissue: '42'\nnotes: 'some notes go here'\n"
                 fd.write(msg)
 
             # Run the script command


### PR DESCRIPTION
This PR updates the structure of the changelog entry. So far, it included the field `pull_request` but we considered `issue` is more generic and more useful.

This PR fixes #10.