### PR TITLE
[publish] Recover from the inconsistent state

### DIFF
--- a/release_tools/repo.py
+++ b/release_tools/repo.py
@@ -18,6 +18,7 @@
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>
+#     Venu Vardhan Reddy Tekula <venu@bitergia.com>
 #
 
 import os
@@ -70,6 +71,18 @@ class GitHandler:
 
     def push(self, remote, ref):
         cmd = ['git', 'push', remote, ref]
+        self._exec(cmd, cwd=self.dirpath, env=self.gitenv)
+
+    def reset_head(self):
+        cmd = ['git', 'reset', 'HEAD^']
+        self._exec(cmd, cwd=self.dirpath, env=self.gitenv)
+
+    def restore_staged(self):
+        cmd = ['git', 'restore', '--staged', '.']
+        self._exec(cmd, cwd=self.dirpath, env=self.gitenv)
+
+    def restore_unstaged(self, dirpath):
+        cmd = ['git', 'restore', dirpath]
         self._exec(cmd, cwd=self.dirpath, env=self.gitenv)
 
     def find_file(self, filename):

--- a/releases/unreleased/recover-from-the-inconsistent-stage-after-publish-fails.yml
+++ b/releases/unreleased/recover-from-the-inconsistent-stage-after-publish-fails.yml
@@ -1,0 +1,14 @@
+---
+title: Recover from the inconsistent state after publish fails
+category: added
+author: Venu Vardhan Reddy Tekula <venu@bitergia.com>
+issue: 18
+notes: >
+    When publish fails, the command leaves the git repository
+    in an inconsistent state. The author needs to check the 
+    status of the repository manually and then fix everything 
+    back to normal.
+    
+    This feature checks for any possible errors; if it finds 
+    any, it informs about them to the user and rollbacks the 
+    operations before it exists.

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -17,6 +17,7 @@
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>
+#     Venu Vardhan Reddy Tekula <venu@bitergia.com>
 #
 
 import os
@@ -189,6 +190,11 @@ class TestPublish(unittest.TestCase):
             mock_project.return_value.repo.push.assert_any_call('myremote', 'master')
             mock_project.return_value.repo.push.assert_any_call('myremote', '0.8.10')
 
+            # Check non called rollback mock calls
+            mock_project.return_value.repo.reset_head.assert_not_called()
+            mock_project.return_value.repo.restore_staged.assert_not_called()
+            mock_project.return_value.repo.restore_unstaged.assert_not_called()
+
     @unittest.mock.patch('release_tools.publish.Project')
     def test_only_publish_to_remote(self, mock_project):
         """Test if when '--only-push' is set only tries to push the release commits and tags."""
@@ -242,7 +248,7 @@ class TestPublish(unittest.TestCase):
         runner = click.testing.CliRunner(mix_stderr=False)
 
         with runner.isolated_filesystem() as fs:
-            dirpath =  os.path.join(fs, 'releases', 'unreleased')
+            dirpath = os.path.join(fs, 'releases', 'unreleased')
             mock_project.return_value.unreleased_changes_path = dirpath
 
             # Run the command
@@ -293,6 +299,10 @@ class TestPublish(unittest.TestCase):
             # Check called mock calls
             mock_project.return_value.repo.rm.assert_called()
 
+            # Check called rollback mock calls
+            mock_project.return_value.repo.restore_staged.assert_called()
+            mock_project.return_value.repo.restore_unstaged.assert_called()
+
             # Check non called mock calls not called
             mock_project.return_value.repo.add.assert_not_called()
             mock_project.return_value.repo.commit.assert_not_called()
@@ -332,6 +342,10 @@ class TestPublish(unittest.TestCase):
             # Check called mock calls
             mock_project.return_value.repo.rm.assert_called()
             mock_project.return_value.repo.add.assert_called_once_with(version_file)
+
+            # Check called rollback mock calls
+            mock_project.return_value.repo.restore_staged.assert_called()
+            mock_project.return_value.repo.restore_unstaged.assert_called()
 
             # Check non called mock calls not called
             mock_project.return_value.repo.commit.assert_not_called()
@@ -373,6 +387,10 @@ class TestPublish(unittest.TestCase):
             mock_project.return_value.repo.rm.assert_called()
             mock_project.return_value.repo.add.assert_any_call(version_file)
             mock_project.return_value.repo.add.assert_any_call(pyproject_file)
+
+            # Check called rollback mock calls
+            mock_project.return_value.repo.restore_staged.assert_called()
+            mock_project.return_value.repo.restore_unstaged.assert_called()
 
             # Check non called mock calls not called
             mock_project.return_value.repo.commit.assert_not_called()
@@ -419,6 +437,10 @@ class TestPublish(unittest.TestCase):
             mock_project.return_value.repo.add.assert_any_call(version_file)
             mock_project.return_value.repo.add.assert_any_call(pyproject_file)
             mock_project.return_value.repo.add.assert_any_call(notes_file)
+
+            # Check called rollback mock calls
+            mock_project.return_value.repo.restore_staged.assert_called()
+            mock_project.return_value.repo.restore_unstaged.assert_called()
 
             # Check non called mock calls not called
             mock_project.return_value.repo.commit.assert_not_called()
@@ -483,6 +505,10 @@ class TestPublish(unittest.TestCase):
             # The process failed when commit command was called
             mock_project.return_value.repo.commit.assert_called_once_with("Release 0.8.10",
                                                                           "John Smith <jsmith@example.org>")
+
+            # Check called rollback mock calls
+            mock_project.return_value.repo.reset_head.assert_called()
+            mock_project.return_value.repo.restore_unstaged.assert_called()
 
             # Tag and push methods were not called
             mock_project.return_value.repo.tag.assert_not_called()


### PR DESCRIPTION
If publish fails, the command leaves the git repository in an inconsistent state. This PR informs about the possible errors and adds the support of rollback to the last consistent state. This is needed to save the manual effort of the user to fix the status of the repository. Tests are added accordingly.

Fixes #18.