### PR TITLE
[tests] Replace coveralls with codecov

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,16 +21,19 @@ jobs:
         run: |
           source $HOME/.poetry/env
           poetry install -vvv
-          poetry add -D coveralls
+          poetry add -D coverage
       - name: Lint with flake8
         run: |
           source $HOME/.poetry/env
           poetry run flake8
-      - name: Tests and Coveralls
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Tests and coverage
         run: |
           source $HOME/.poetry/env
-          cd tests
-          poetry run coverage run --source=release_tools run_tests.py
-          poetry run coveralls --service=github
+          poetry run coverage run --source=release_tools tests/run_tests.py
+          poetry run coverage report -m
+          poetry run coverage xml
+      - name: Send coverage report to codecov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.xml
+          fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GrimoireLab Release Tools [![Build Status](https://github.com/Bitergia/release-tools/workflows/tests/badge.svg)](https://github.com/Bitergia/release-tools/actions?query=workflow:tests+branch:master+event:push)
+# GrimoireLab Release Tools [![Build Status](https://github.com/Bitergia/release-tools/workflows/tests/badge.svg)](https://github.com/Bitergia/release-tools/actions?query=workflow:tests+branch:master+event:push) [![codecov](https://codecov.io/gh/Bitergia/release-tools/branch/master/graph/badge.svg?token=T60WC78FPR)](https://codecov.io/gh/Bitergia/release-tools)
 
 Set of tools to generate GrimoireLab releases.
 


### PR DESCRIPTION
This PR replaces the coveralls service with codecov in the tests workflow as there are a lot of problems with coveralls lately.

Closes #26 