### PR TITLE
[tests] Set the fetch-depth to 10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,8 @@ jobs:
     
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 10 # fetch all tags and branches
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
The codecov gives a warning if the depth is not set accordingly during actions/checkout.
```
->  Issue detecting commit SHA. Please run actions/checkout with fetch-depth > 1 or set to 0
```

This PR is required to override this error.