### PR TITLE
[notes] Add option to update authors file content

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,15 @@ $ notes "MyApp" 0.2.0 --dry-run
    a magician.
 ```
 
+If you want to add the contributor names of these release notes to the 
+AUTHORS file, use the flag `--authors`.
+
+```
+$ notes "MyApp" 0.2.0 --authors
+Release notes file '0.2.0.md' created
+Authors file updated
+```
+
 ### publish
 
 This script will generate a new release in the repository.

--- a/release_tools/project.py
+++ b/release_tools/project.py
@@ -17,6 +17,7 @@
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>
+#     Venu Vardhan Reddy Tekula <venu@bitergia.com>
 #
 
 import os
@@ -25,6 +26,7 @@ from release_tools.repo import GitHandler
 
 
 NEWS_FILENAME = 'NEWS'
+AUTHORS_FILENAME = 'AUTHORS'
 PYPROJECT_FILENAME = 'pyproject.toml'
 VERSION_FILENAME = '_version.py'
 
@@ -50,6 +52,12 @@ class Project:
         """Path the the news file."""
 
         return os.path.join(self.basepath, NEWS_FILENAME)
+
+    @property
+    def authors_file(self):
+        """Path the the authors file."""
+
+        return os.path.join(self.basepath, AUTHORS_FILENAME)
 
     @property
     def pyproject_file(self):

--- a/release_tools/publish.py
+++ b/release_tools/publish.py
@@ -155,6 +155,16 @@ def add_release_files(project, version):
 
     project.repo.add(news_file)
 
+    # Add AUTHORS file
+    authors_file = project.authors_file
+
+    if not os.path.exists(authors_file):
+        msg = "authors file not found"
+        rollback_add_release_files(project)
+        raise click.ClickException(msg)
+
+    project.repo.add(authors_file)
+
     click.echo("done")
 
 

--- a/releases/unreleased/add-option-to-update-authors-file-content.yml
+++ b/releases/unreleased/add-option-to-update-authors-file-content.yml
@@ -1,0 +1,12 @@
+---
+title: Add option to update AUTHORS file content
+category: added
+author: Venu Vardhan Reddy Tekula <venu@bitergia.com>
+issue: null
+notes: >
+    The AUTHORS file has to updated periodically with the
+    names of the contributors. This has to be done manually.
+    
+    This feature adds the option `--authors` which allows to
+    update the AUTHORS file with the names extracted from the
+    unreleased changelog entries.

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -17,6 +17,7 @@
 #
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>
+#     Venu Vardhan Reddy Tekula <venu@bitergia.com>
 #
 
 import unittest
@@ -75,6 +76,18 @@ class TestProject(unittest.TestCase):
 
         expected = "/tmp/repo/NEWS"
         self.assertEqual(project.news_file, expected)
+
+    @unittest.mock.patch('release_tools.project.GitHandler.root_path',
+                         new_callable=unittest.mock.PropertyMock)
+    def test_authors_file(self, mock_root_path):
+        """Check if the property returns the authors file path"""
+
+        mock_root_path.return_value = "/tmp/repo/"
+
+        project = Project('/tmp/repo/')
+
+        expected = "/tmp/repo/AUTHORS"
+        self.assertEqual(project.authors_file, expected)
 
     @unittest.mock.patch('release_tools.project.GitHandler.find_file')
     @unittest.mock.patch('release_tools.project.GitHandler.root_path',


### PR DESCRIPTION
This PR adds the option '--authors' which allows updating the authors file with the contributors' names.

The tests are added and the documentation is updated accordingly.