### PR TITLE
[gha] Add poetry path as env var

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,12 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install poetry
-        run: curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
+        run: |
+          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
+          echo "PATH=$HOME/.poetry/bin:$PATH" >> $GITHUB_ENV
       - name: Build distributions
-        run: poetry build
+        run: |
+          poetry build
       - name: Upload distribution artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -81,10 +84,14 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install poetry
-        run: curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
+        run: |
+          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
+          echo "PATH=$HOME/.poetry/bin:$PATH" >> $GITHUB_ENV
       - name: Configure pypi credentials
         env:
           PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-        run: poetry config http-basic.pypi __token__ "$PYPI_API_TOKEN"
+        run: |
+          poetry config http-basic.pypi __token__ "$PYPI_API_TOKEN"
       - name: Publish release to pypi
-        run: poetry publish
+        run: |
+          poetry publish

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,19 +18,18 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}    
       - name: Install and set up Poetry
-        run: curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
+        run: |
+          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
+          echo "PATH=$HOME/.poetry/bin:$PATH" >> $GITHUB_ENV
       - name: Install dependencies
         run: |
-          source $HOME/.poetry/env
           poetry install -vvv
           poetry add -D coverage
       - name: Lint with flake8
         run: |
-          source $HOME/.poetry/env
           poetry run flake8
       - name: Tests and coverage
         run: |
-          source $HOME/.poetry/env
           poetry run coverage run --source=release_tools tests/run_tests.py
           poetry run coverage report -m
           poetry run coverage xml


### PR DESCRIPTION
This PR adds the path configuration as an env variable for poetry. Now, it doesn't need to activate the virtual environment each time before we use a poetry command in the GHA workflows.
