### PR TITLE
[gha] Reusable workflow to check if a changelog was included

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,40 @@
+name: Check changelog file included
+
+on: workflow_call
+
+jobs:
+  valid_changelog_file:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+            fetch-depth: 2
+
+      - name: Check changelog file added
+        run: git diff --name-only --diff-filter=A HEAD^ HEAD | grep 'releases/unreleased'
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install pyyaml to validate file
+        run: pip install pyyaml
+
+      - name: Validate the yaml files added
+        run: |
+          filenames=$(git diff --name-only --diff-filter=A HEAD^ HEAD | grep 'releases/unreleased')
+          echo $filenames | while read filename;
+          do
+            echo -n "$filename: "
+            if ! [ -s $filename ]; then
+              echo "Empty changelog file"
+              exit 1
+            fi
+            python -c 'import yaml, sys; yaml.safe_load(sys.stdin)' < $filename
+            if [ $? != 0 ]; then
+              echo "Invalid yaml format"
+              exit 1
+            fi
+            echo "OK"
+          done


### PR DESCRIPTION
This pull request adds a new GitHub workflow to check if a changelog file was included in the last pull request and validate the contents if it is empty or valid YAML file.

It can be used from a different repository using

```
name: Changelog included

on:
  pull_request:
    branches:
      - master

jobs:
  check-changelog:
    uses: bitergia/release-tools/.github/workflows/changelog.yml@master
```