### PR TITLE
[repo] Fix root_path when a repo is a submodule

### DIFF
--- a/release_tools/repo.py
+++ b/release_tools/repo.py
@@ -46,9 +46,9 @@ class GitHandler:
 
     @property
     def root_path(self):
-        path_ = self._get_submodule_root_path()
+        basepath = self._get_submodule_root_path()
 
-        if not path_:
+        if not basepath:
             basepath = self._get_root_path()
 
         return basepath

--- a/releases/unreleased/fix-repo-when-is-a-submodule.yml
+++ b/releases/unreleased/fix-repo-when-is-a-submodule.yml
@@ -1,0 +1,8 @@
+---
+title: Fix repo when is a submodule
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  A variable was referenced before assignment
+  when the repository was a submodule.


### PR DESCRIPTION
Basepath variable was referenced before assignment when the repository is a submodule.
