### PR TITLE
Upgrade codecov GitHub Action to v2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
           poetry run coverage report -m
           poetry run coverage xml
       - name: Send coverage report to codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           file: ./coverage.xml
           fail_ci_if_error: true


### PR DESCRIPTION
The codecov-action v1 is deprecated. This commit upgrades it to v2, fixing the compatibility problems we run into after
submitting new PRs.
