### PR TITLE
Add missed changelog entry

### DIFF
--- a/releases/unreleased/drop-python-3.6-support.yml
+++ b/releases/unreleased/drop-python-3.6-support.yml
@@ -1,0 +1,10 @@
+title: Drop Python 3.6 support
+category: removed
+author: Santiago Dueñas <sduenas@bitergia.com>
+issue: null
+notes: >
+    Python 3.6 reached the end of life at
+    the end of 2021. This means it won't receive
+    new updates or patches to fix security issues.
+    Therefore, this package will only work with
+    Python >= 3.7 from now on.


### PR DESCRIPTION
This entry explains why Python 3.6 support was dropped. It belongs to a previous commit.
