### PR TITLE
Fix adding authors with the notes command

### DIFF
--- a/release_tools/notes.py
+++ b/release_tools/notes.py
@@ -345,7 +345,7 @@ class AuthorsFileComposer:
 
         authors = self._extract_authors(project)
 
-        for entry_list in entries.values():
+        for _, entry_list in sorted(entries.items()):
             for entry in ReleaseNotesComposer._sort_entries_by_id(entry_list):
                 if not entry.author:
                     continue
@@ -369,7 +369,8 @@ class AuthorsFileComposer:
         # Read old content
         try:
             with open(authors_file, 'r') as fd:
-                authors = fd.read().splitlines()[:-1]
+                authors = fd.read().splitlines()
+                authors = [author for author in authors if author]
         except FileNotFoundError:
             authors = []
 

--- a/releases/unreleased/fix-notes-command-when-adding-authors.yml
+++ b/releases/unreleased/fix-notes-command-when-adding-authors.yml
@@ -1,0 +1,9 @@
+---
+title: Notes command removes last author
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: 46
+notes: >
+  notes command was removing the last author from
+  the `AUTHORS` file when the file did not end with a
+  blank line.


### PR DESCRIPTION
This commit fixes the issue that removes the last author
when the file AUTHORS doesn't end with and new line.

Fixes #46 
