### PR TITLE
[semverup] Add arguments to increase version number

### DIFF
--- a/releases/unreleased/arguments-to-increase-version-manually.yml
+++ b/releases/unreleased/arguments-to-increase-version-manually.yml
@@ -1,0 +1,9 @@
+---
+title: Option `--bump-version` to increase version manually
+category: added
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Include `--bump-version=[MAJOR, MINOR, PATCH]` argument to
+  `sermverup` command to increase the version number regardless
+  the release notes changes.


### PR DESCRIPTION
This PR adds '--bump-major', '--bump-minor' and 'bump-patch'
arguments to 'semverup' to increase the version number manually.

This PR includes also some tests.
