### PR TITLE
[notes] Add support for multiple authors

### DIFF
--- a/release_tools/notes.py
+++ b/release_tools/notes.py
@@ -345,12 +345,20 @@ class AuthorsFileComposer:
 
         authors = self._extract_authors(project)
 
+        def _check_author_exists_already(author):
+            if author not in authors:
+                authors.append(author)
+
         for _, entry_list in sorted(entries.items()):
             for entry in ReleaseNotesComposer._sort_entries_by_id(entry_list):
                 if not entry.author:
                     continue
-                if entry.author not in authors:
-                    authors.append(entry.author)
+
+                if type(entry.author) is list:
+                    for author in entry.author:
+                        _check_author_exists_already(author)
+                else:
+                    _check_author_exists_already(entry.author)
 
         content = ""
 

--- a/releases/unreleased/notes-command-supports-multiple-authors-in-changelog-entries.yml
+++ b/releases/unreleased/notes-command-supports-multiple-authors-in-changelog-entries.yml
@@ -1,0 +1,14 @@
+---
+title: Notes command supports multiple authors in changelog entries
+category: added
+author:
+issue: 49
+notes: >
+    The notes command supports exporting of multiple authors
+    from the changelog entries. You can add more than one
+    author to the changelog entry by defining them as
+    ```
+    author:
+        - John Smith <jsmith@example.com>
+        - John Doe <jdoe@example.com>
+    ```

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -76,7 +76,7 @@ NEWS_FILE_CONTENT = """# Releases\n\n""" + RELEASE_NOTES_CONTENT + NEWS_FILE_ORI
 
 AUTHORS_FILE_ORIGINAL_CONTENT = """jdoe\n\n"""
 AUTHORS_FILE_ORIGINAL_CONTENT_NO_NEW_LINE = """jdoe"""
-AUTHORS_FILE_CONTENT = """jdoe\njsmith\n\n"""
+AUTHORS_FILE_CONTENT = """jdoe\njsmith\njwick\n\n"""
 RELEASE_NOTES_FILE_ALREADY_EXISTS_ERROR = (
     "Error: Release notes for version 0.8.10 already exist. Use '--overwrite' to replace it."
 )
@@ -121,7 +121,7 @@ class TestNotes(unittest.TestCase):
             CategoryChange.ADDED,
             CategoryChange.FIXED,
         ]
-        authors = ['jsmith', 'jdoe', 'jsmith', 'jdoe', 'jsmith']
+        authors = ['jsmith', 'jdoe', '\n- jsmith\n- jdoe\n- jwick', 'jdoe', 'jsmith']
         issues = [1, 2, 3, 'null', 'null']
         notes = [True, False, False, False, True]
         notes_txt = (
@@ -389,7 +389,7 @@ class TestNotes(unittest.TestCase):
             with open(authors_file, 'r') as fd:
                 text = fd.read()
 
-            expected = """jsmith\njdoe\n\n"""
+            expected = """jsmith\njdoe\njwick\n\n"""
             self.assertEqual(text, expected)
 
     @unittest.mock.patch('release_tools.notes.ReleaseNotesComposer._datetime_utcnow_str')


### PR DESCRIPTION
This PR adds code to support export of multiple authors from the changelog entry.

Resolves #49 