### PR TITLE
Improve file name for changelog

### DIFF
--- a/release_tools/entry.py
+++ b/release_tools/entry.py
@@ -30,6 +30,7 @@
 
 import enum
 import os
+import re
 
 import yaml
 
@@ -138,6 +139,7 @@ def determine_filepath(dirpath, title):
     """Returns the changelog entry filename."""
 
     filename = title.replace(' ', '-').lower()
+    filename = re.sub('[^a-zA-Z0-9_-]', '', filename)
     filename = filename[0:MAX_FILENAME_LENGTH - 1] + YAML_FILE_EXTENSION
     filepath = os.path.join(dirpath, filename)
 

--- a/releases/unreleased/changelog-valid-filenames.yml
+++ b/releases/unreleased/changelog-valid-filenames.yml
@@ -1,0 +1,9 @@
+---
+title: Changelog valid filenames
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+    Creating filename from the title could create invalid
+    paths. This commits change the way the filename is 
+    created from the title removing many of the special chars.

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -216,6 +216,15 @@ class TestDetermineFilePath(unittest.TestCase):
         filepath = determine_filepath(dirpath, "my change")
         self.assertEqual(filepath, expected)
 
+    def test_random_filepath(self):
+        """Check it the right filepath is returned"""
+
+        dirpath = "/tmp/repo/releases/unreleased/"
+        expected = os.path.join(dirpath, "releasepublish-my-custom-change.yml")
+
+        filepath = determine_filepath(dirpath, '[release/publish] My "custom" change')
+        self.assertEqual(filepath, expected)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This commit updates how `changelog` creates the file name and ignores any characters other than alphanumeric, `_` or `-` to avoid errors when using `/`, `'` or `"`, among others, in titles.


