### PR TITLE
Options to create release candidates

### DIFF
--- a/release_tools/publish.py
+++ b/release_tools/publish.py
@@ -44,7 +44,9 @@ from release_tools.repo import RepositoryError
 @click.option('--push', 'remote', help="Push release to the given remote.")
 @click.option('--only-push', is_flag=True,
               help="Do not generate a release commit; push the existing one.")
-def publish(version, author, remote, only_push):
+@click.option('--no-cleanup', is_flag=True,
+              help="Do not remove changelog entries from the repository.")
+def publish(version, author, remote, only_push, no_cleanup):
     """Publish a new release.
 
     This script will generate a new release in the repository.
@@ -54,12 +56,15 @@ def publish(version, author, remote, only_push):
     To run it, you will need to provide the version number and
     the author of the new release.
 
-    By default the command does not push the commit release to a
+    By default, the command does not push the commit release to a
     remote repository. To force it, use the parameter `--push`
     including the name of the remote where commits will be pushed.
 
     It is also possible to push only the commit release and its tag.
     To do so, set '--only-push' together with '--push' option.
+
+    When '--no-cleanup' argument is specified, do not remove changelog
+    entries.
 
     VERSION: version of the new release.
 
@@ -76,7 +81,8 @@ def publish(version, author, remote, only_push):
 
     try:
         if not only_push:
-            remove_unreleased_changelog_entries(project)
+            if not no_cleanup:
+                remove_unreleased_changelog_entries(project)
             add_release_files(project, version)
             commit(project, version, author)
 

--- a/releases/unreleased/option-for-release-candidates-versions.yml
+++ b/releases/unreleased/option-for-release-candidates-versions.yml
@@ -1,0 +1,20 @@
+---
+title: Option for release candidates versions
+category: added
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+    Include a new argument to `semverup` to create pre-releases versions.
+    
+    If the option `--pre-release` is included and the current version
+    is not a release candidate, it will create a new pre-release version
+    based on files or `--bump-version` argument. If the current version
+    is a release candidate, it will increase its pre-release part. For
+    example, in a repository with a bugfix changelog entry:
+      - `0.2.0` + `semverup --pre-release` = `0.2.1-rc.1`
+      - `0.2.1-rc.1` + `semverup --pre-release` = `0.2.1-rc.2`
+    
+    When the version is a pre-release, and `--pre-release` is not specified,
+    it will remove the pre-release part and generate the final version. In a
+    repository with changelog entries:
+      -  `0.2.2-rc.1` + `semverup` = `0.2.2`

--- a/releases/unreleased/publish-unreleased-files-management.yml
+++ b/releases/unreleased/publish-unreleased-files-management.yml
@@ -1,0 +1,8 @@
+---
+title: 'Option to not cleanup on publishing'
+category: added
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+    Running `publish` with `--no-cleanup' option doesn't remove
+    any changelog entry from the repository.


### PR DESCRIPTION
Include a new option in the `publish` command (`--no-cleanup`) for not removing changelog entries when a new release is generated.

Include a new option in the `semverup` command (`--prerelease`) to create a new release candidate based on the notes or the changelog entries. Some cases for the `semverup` command:

Initial version: `0.2.0`:
- No changelog `semverup --prerelease`: `error`
- Changelog minor `semverup --prerelease`: `0.3.0-rc.1`
- `semverup --bump-version=PATCH --prerelease`: `0.2.1-rc.1`

Initial version:  `0.2.1-rc.1`:
- No changelog `semverup`: `error`
- No changelog `semverup --prerelease`: `error`
- With changelog `semverup`: `0.2.1`
- With changelog `semverup --prerelease`: `0.2.1-rc.2`
- `semverup --bump-version=PATCH`: `0.2.1`
- `semverup --bump-version=PATCH --prerelease`: `0.2.1-rc.2`
