### PR TITLE
Update what version increments each category and add 'dependecy' category

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,8 @@ and the type of the change.
 5. Feature removal
 6. Security fix
 7. Performance improvement
-8. Other
+8. Dependency
+9. Other
 
 : 2
 ```

--- a/README.md
+++ b/README.md
@@ -139,18 +139,23 @@ and the type of the change.
 ```
 >> Please specify the category of your change
 
-1. New feature
-2. Bug fix
-3. Feature change
-4. New deprecation
-5. Feature removal
-6. Security fix
-7. Performance improvement
-8. Dependency
-9. Other
+1. New feature (added)
+2. Bug fix (fixed)
+3. Breaking change (changed)
+4. New deprecation (deprecated)
+5. Feature removal (removed)
+6. Security fix (security)
+7. Performance improvement (performance)
+8. Dependencies updated (dependency)
+9. Other (other)
 
 : 2
 ```
+
+Each category updates a different version number:
+- Major version: `changed` and `removed`.
+- Minor version: `added`, `deprecated`, `security`, `performance` and `other`.
+- Patch version: `fixed` and `dependency`.
 
 At the end of the process, a text editor will open to let you review
 the entry and make the final changes. The editor will be the default

--- a/release_tools/changelog.py
+++ b/release_tools/changelog.py
@@ -63,7 +63,8 @@ def category_prompt():
     """Prompt category to read the type of a change"""
 
     prompt_msg = ">> Please specify the category of your change\n\n"
-    prompt_msg += "\n".join(["{}. {}".format(cat.value, cat.title) for cat in CategoryChange])
+    prompt_msg += "\n".join(["{}. {} ({})".format(cat.value, cat.title, cat.category)
+                             for cat in CategoryChange])
     prompt_msg += "\n\n"
     return prompt_msg
 

--- a/release_tools/entry.py
+++ b/release_tools/entry.py
@@ -59,7 +59,8 @@ class CategoryChange(enum.Enum):
     REMOVED = (5, 'removed', 'Feature removal')
     SECURITY = (6, 'security', 'Security fix')
     PERFORMANCE = (7, 'performance', 'Performance improvement')
-    OTHER = (8, 'other', 'Other')
+    DEPENDENCY = (8, 'dependency', 'Dependencies updated')
+    OTHER = (9, 'other', 'Other')
 
     @classmethod
     def values(cls):

--- a/release_tools/entry.py
+++ b/release_tools/entry.py
@@ -45,22 +45,23 @@ MAX_FILENAME_LENGTH = 99 - len(YAML_FILE_EXTENSION)
 class CategoryChange(enum.Enum):
     """Possible category types."""
 
-    def __new__(cls, value, category, title):
+    def __new__(cls, value, category, title, bump_version):
         obj = object.__new__(cls)
         obj._value_ = value
         obj.category = category
         obj.title = title
+        obj.bump_version = bump_version
         return obj
 
-    ADDED = (1, 'added', 'New feature')
-    FIXED = (2, 'fixed', 'Bug fix')
-    CHANGED = (3, 'changed', 'Feature change')
-    DEPRECATED = (4, 'deprecated', 'New deprecation')
-    REMOVED = (5, 'removed', 'Feature removal')
-    SECURITY = (6, 'security', 'Security fix')
-    PERFORMANCE = (7, 'performance', 'Performance improvement')
-    DEPENDENCY = (8, 'dependency', 'Dependencies updated')
-    OTHER = (9, 'other', 'Other')
+    ADDED = (1, 'added', 'New feature', 'minor')
+    FIXED = (2, 'fixed', 'Bug fix', 'patch')
+    CHANGED = (3, 'changed', 'Breaking change', 'major')
+    DEPRECATED = (4, 'deprecated', 'New deprecation', 'minor')
+    REMOVED = (5, 'removed', 'Feature removal', 'major')
+    SECURITY = (6, 'security', 'Security fix', 'minor')
+    PERFORMANCE = (7, 'performance', 'Performance improvement', 'minor')
+    DEPENDENCY = (8, 'dependency', 'Dependencies updated', 'patch')
+    OTHER = (9, 'other', 'Other', 'minor')
 
     @classmethod
     def values(cls):

--- a/release_tools/semverup.py
+++ b/release_tools/semverup.py
@@ -35,8 +35,7 @@ import click
 import semver
 import tomlkit.toml_file
 
-from release_tools.entry import (CategoryChange,
-                                 read_changelog_entries)
+from release_tools.entry import read_changelog_entries
 from release_tools.project import Project
 from release_tools.repo import RepositoryError
 
@@ -202,12 +201,18 @@ def determine_new_version_number(project, current_version, pre_release):
 
     bump_patch = False
     bump_minor = False
+    bump_major = False
 
     for entry in entries.values():
-        if entry.category != CategoryChange.FIXED:
-            bump_minor = True
+        if entry.category.bump_version == 'major':
+            if current_version.major == 0:
+                bump_minor = True
+            else:
+                bump_major = True
             break
-        else:
+        elif entry.category.bump_version == 'minor':
+            bump_minor = True
+        elif entry.category.bump_version == 'patch':
             bump_patch = True
 
     next_version = None
@@ -216,6 +221,8 @@ def determine_new_version_number(project, current_version, pre_release):
         next_version = current_version.bump_patch()
     if bump_minor:
         next_version = current_version.bump_minor()
+    if bump_major:
+        next_version = current_version.bump_major()
     if next_version and pre_release:
         next_version = next_version.bump_prerelease()
 

--- a/releases/unreleased/categories-bumps-version-changed.yml
+++ b/releases/unreleased/categories-bumps-version-changed.yml
@@ -1,0 +1,14 @@
+---
+title: New categories definition
+category: changed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: 55
+notes: >
+    Previously, only the `fixed` notes incremented the `patch` version, and the other changes
+    incremented MINOR. We updated this behavior.
+
+    From now on, `changed` and `removed` entries increment major version.
+    `added`, `deprecated`, `security`, `performance` and `other` increment
+    the minor version. `Fixed` and `dependency` increment the patch version.
+
+    If the version is 0.x.x new entries will upgrade minor version at most.

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -46,10 +46,10 @@ INVALID_TITLE_ERROR = (
 INVALID_CATEGORY_ERROR = [
     "Error",
     r" Invalid value for \"|\'-c\"|\' / \"|\'--category\"|\'",
-    " valid options are ['added', 'fixed', 'changed', 'deprecated', 'removed', 'security', 'performance', 'other']"
+    " valid options are ['added', 'fixed', 'changed', 'deprecated', 'removed', 'security', 'performance', 'dependency', 'other']"
 ]
 INVALID_CATEGORY_INDEX_ERROR = (
-    r"Error: Invalid value for \"|\'-c\"|\' / \"|\'--category\"|\': please select an index between 1 and 8"
+    r"Error: Invalid value for \"|\'-c\"|\' / \"|\'--category\"|\': please select an index between 1 and 9"
 )
 MOCK_OS_ERROR = (
     "Error: Unable to create directory. mock os error"

--- a/tests/test_entry.py
+++ b/tests/test_entry.py
@@ -57,7 +57,7 @@ class TestCategoryChange(unittest.TestCase):
 
         self.assertEqual(CategoryChange(1), CategoryChange.ADDED)
         self.assertEqual(CategoryChange(2), CategoryChange.FIXED)
-        self.assertEqual(CategoryChange(8), CategoryChange.OTHER)
+        self.assertEqual(CategoryChange(9), CategoryChange.OTHER)
 
     def test_values(self):
         """Test 'values' class method"""
@@ -65,7 +65,7 @@ class TestCategoryChange(unittest.TestCase):
         expected = [
             'added', 'fixed', 'changed',
             'deprecated', 'removed', 'security',
-            'performance', 'other'
+            'performance', 'dependency', 'other'
         ]
 
         values = CategoryChange.values()


### PR DESCRIPTION
This PR includes a new Category for updates on dependencies. This is needed when a new version is required when dependencies are updated. It will increase the `patch` version.

Previously, only the 'fixed' notes incremented the 'patch' version, and the other changes incremented MINOR. We updated this behavior.

From now on, 'changed' and 'removed' entries increment major version. 'Added', 'deprecated', 'security', 'performance' and
 'other' increment the minor version. 'Fixed' and 'dependency' increment the patch version.

Closes https://github.com/Bitergia/release-tools/issues/55