### PR TITLE
[pyproject] Update build system to poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,5 +48,5 @@ tomlkit = "^0.5.8"
 flake8 = "^3.8.4"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This PR updates the build system in the pyproject file to poetry-core.

The previous build system was 'poetry' which is deprecated and now it should be poetry-core.