### PR TITLE
[notes] Move notes to a new directory for every version

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,11 @@ $ notes "MyApp" 0.2.0
 Release notes file '0.2.0.md' created
 ```
 
+Changelog entries included in the release notes are moved to a new
+directory in 'unreleased/processed'. If you are running multiple
+release candidates, and you don't want to include the same notes in
+successive release candidates, use the flag '--pre-release'.
+
 If you also want to add the content of these release notes to the `NEWS`
 file, use the flag `--news`.
 

--- a/release_tools/project.py
+++ b/release_tools/project.py
@@ -32,6 +32,7 @@ VERSION_FILENAME = '_version.py'
 
 RELEASES_DIRNAME = 'releases'
 UNRELEASED_CHANGES_DIRNAME = 'unreleased'
+UNRELEASED_ENTRIES_PROCESSED = 'processed'
 
 
 class Project:
@@ -84,3 +85,9 @@ class Project:
         """Path where the unreleased changes entries are stored."""
 
         return os.path.join(self.releases_path, UNRELEASED_CHANGES_DIRNAME)
+
+    @property
+    def unreleased_processed_entries_path(self):
+        """Path where processed unreleased changes entries are stored."""
+
+        return os.path.join(self.unreleased_changes_path, UNRELEASED_ENTRIES_PROCESSED)

--- a/release_tools/publish.py
+++ b/release_tools/publish.py
@@ -97,7 +97,7 @@ def remove_unreleased_changelog_entries(project):
 
     click.echo("Cleaning directories...", nl=False)
 
-    dirpath = project.unreleased_changes_path
+    dirpath = project.unreleased_processed_entries_path
 
     if not os.path.exists(dirpath):
         click.echo("done")

--- a/release_tools/repo.py
+++ b/release_tools/repo.py
@@ -82,6 +82,10 @@ class GitHandler:
         cmd = ['git', 'restore', dirpath]
         self._exec(cmd, cwd=self.dirpath, env=self.gitenv)
 
+    def mv(self, srcpath, destpath):
+        cmd = ['git', 'mv', srcpath, destpath]
+        self._exec(cmd, cwd=self.dirpath, env=self.gitenv)
+
     def find_file(self, filename):
         """Find a file in the repository.
 

--- a/releases/unreleased/changelog-location-updated-between-versions.yml
+++ b/releases/unreleased/changelog-location-updated-between-versions.yml
@@ -1,0 +1,10 @@
+---
+title: Generate release notes for pre-releases
+category: added
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: |
+  The flag `--pre-release`, on the command `notes`, generates the notes
+  of a release candidate. Release notes include the changes in between
+  releases - regular and candidate releases - while the release candidate
+  notes only include the latest changes since the previous release.

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -67,6 +67,18 @@ class TestProject(unittest.TestCase):
 
     @unittest.mock.patch('release_tools.project.GitHandler.root_path',
                          new_callable=unittest.mock.PropertyMock)
+    def test_unreleased_processed_entries_path(self, mock_root_path):
+        """Check if the property returns the path to the unreleased processed changes"""
+
+        mock_root_path.return_value = "/tmp/repo/"
+
+        project = Project('/tmp/repo/')
+
+        expected = "/tmp/repo/releases/unreleased/processed"
+        self.assertEqual(project.unreleased_processed_entries_path, expected)
+
+    @unittest.mock.patch('release_tools.project.GitHandler.root_path',
+                         new_callable=unittest.mock.PropertyMock)
     def test_news_file(self, mock_root_path):
         """Check if the property returns the news file path"""
 

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -106,7 +106,7 @@ class TestPublish(unittest.TestCase):
             self.setup_release_notes(fs, notes_file, newsfile=news_file, authorsfile=authors_file)
 
             mock_read_changelog.return_value = files
-            mock_project.return_value.unreleased_changes_path = fs
+            mock_project.return_value.unreleased_processed_entries_path = fs
             mock_project.return_value.releases_path = fs
             mock_project.return_value.version_file = version_file
             mock_project.return_value.pyproject_file = pyproject_file
@@ -166,7 +166,7 @@ class TestPublish(unittest.TestCase):
             self.setup_release_notes(fs, notes_file, newsfile=news_file, authorsfile=authors_file)
 
             mock_read_changelog.return_value = files
-            mock_project.return_value.unreleased_changes_path = fs
+            mock_project.return_value.unreleased_processed_entries_path = fs
             mock_project.return_value.releases_path = fs
             mock_project.return_value.version_file = version_file
             mock_project.return_value.pyproject_file = pyproject_file
@@ -315,6 +315,7 @@ class TestPublish(unittest.TestCase):
             self.setup_release_notes(fs, notes_file, newsfile=news_file, authorsfile=authors_file)
 
             mock_project.return_value.unreleased_changes_path = unreleased_dir
+            mock_project.return_value.unreleased_processed_entries_path = os.path.join(unreleased_dir, 'processed')
             mock_project.return_value.releases_path = fs
             mock_project.return_value.version_file = version_file
             mock_project.return_value.pyproject_file = pyproject_file
@@ -348,7 +349,7 @@ class TestPublish(unittest.TestCase):
             pyproject_file = os.path.join(fs, 'pyproject.toml')
 
             mock_read_changelog.return_value = files
-            mock_project.return_value.unreleased_changes_path = fs
+            mock_project.return_value.unreleased_processed_entries_path = fs
             mock_project.return_value.releases_path = fs
             mock_project.return_value.version_file = None
             mock_project.return_value.pyproject_file = pyproject_file
@@ -391,7 +392,7 @@ class TestPublish(unittest.TestCase):
             version_file = os.path.join(fs, '_version.py')
 
             mock_read_changelog.return_value = files
-            mock_project.return_value.unreleased_changes_path = fs
+            mock_project.return_value.unreleased_processed_entries_path = fs
             mock_project.return_value.releases_path = fs
             mock_project.return_value.version_file = version_file
             mock_project.return_value.pyproject_file = None
@@ -435,7 +436,7 @@ class TestPublish(unittest.TestCase):
             pyproject_file = os.path.join(fs, 'pyproject.toml')
 
             mock_read_changelog.return_value = files
-            mock_project.return_value.unreleased_changes_path = fs
+            mock_project.return_value.unreleased_processed_entries_path = fs
             mock_project.return_value.releases_path = fs
             mock_project.return_value.version_file = version_file
             mock_project.return_value.pyproject_file = pyproject_file
@@ -481,7 +482,7 @@ class TestPublish(unittest.TestCase):
             notes_file = os.path.join(fs, '0.8.10.md')
 
             mock_read_changelog.return_value = files
-            mock_project.return_value.unreleased_changes_path = fs
+            mock_project.return_value.unreleased_processed_entries_path = fs
             mock_project.return_value.releases_path = fs
             mock_project.return_value.version_file = version_file
             mock_project.return_value.pyproject_file = pyproject_file
@@ -531,7 +532,7 @@ class TestPublish(unittest.TestCase):
             notes_file = os.path.join(fs, '0.8.10.md')
 
             mock_read_changelog.return_value = files
-            mock_project.return_value.unreleased_changes_path = fs
+            mock_project.return_value.unreleased_processed_entries_path = fs
             mock_project.return_value.releases_path = fs
             mock_project.return_value.version_file = version_file
             mock_project.return_value.pyproject_file = pyproject_file
@@ -586,7 +587,7 @@ class TestPublish(unittest.TestCase):
             self.setup_release_notes(fs, notes_file, newsfile=news_file, authorsfile=authors_file)
 
             mock_read_changelog.return_value = files
-            mock_project.return_value.unreleased_changes_path = fs
+            mock_project.return_value.unreleased_processed_entries_path = fs
             mock_project.return_value.releases_path = fs
             mock_project.return_value.version_file = version_file
             mock_project.return_value.pyproject_file = pyproject_file
@@ -656,7 +657,7 @@ class TestPublish(unittest.TestCase):
             self.setup_release_notes(fs, notes_file, newsfile=news_file, authorsfile=authors_file)
 
             mock_read_changelog.return_value = files
-            mock_project.return_value.unreleased_changes_path = fs
+            mock_project.return_value.unreleased_processed_entries_path = fs
             mock_project.return_value.releases_path = fs
             mock_project.return_value.version_file = version_file
             mock_project.return_value.pyproject_file = pyproject_file

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -96,6 +96,14 @@ class TestGitHandler(TestCaseRepo):
         file_location = repo.find_file(filename)
         self.assertIsNone(file_location)
 
+    def test_mv_file(self):
+        filename = 'README.md'
+        dest_path = 'README_2.md'
+        repo = GitHandler(self.git_path)
+        repo.mv(filename, dest_path)
+        location_dest = os.path.join(self.git_path, dest_path)
+        self.assertTrue(os.path.exists(location_dest))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
`notes` move the changelog entries to a new directory when they are used for creating a release notes file. `Notes` has a now a new argument `--pre-release`, when it is defined, it ignores `unreleased/processed` notes for creating new release notes, when it is not passed, it includes 'unreleased/processed' in release notes.

`semverup` now updates the version depending on the notes that are in `unreleased` directory and ignores `unreleased/processed`.

`publish` removes the notes at unreleased/processed because are the notes that are already processed and ignores the yml files at `unreleased/*.yml`
