### PR TITLE
[semverup] Next version on semverup fixed

### DIFF
--- a/releases/unreleased/next-version-on-semverup-fixed.yml
+++ b/releases/unreleased/next-version-on-semverup-fixed.yml
@@ -1,0 +1,11 @@
+---
+title: Invalid release candidate version number when adding new changes
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: |
+  `semverup` was not increasing the correct version number
+  when the old version was a release candidate and a new
+  changelog was included. Before it increased `0.0.5-rc.1`
+  to `0.0.5-rc.2` when a minor changelog entry was added
+  while it should be `0.1.0-rc.1`.


### PR DESCRIPTION
`semverup` was not increasing the correct version number when the old version was a release candidate and a new changelog was included. 
It was increasing only the release candidate number. Now it increases correctly the number based on new changelog entries.

Tests are added for almost any case.