### PR TITLE
Force remove processed changelog entries

### DIFF
--- a/release_tools/repo.py
+++ b/release_tools/repo.py
@@ -55,7 +55,7 @@ class GitHandler:
         self._exec(cmd, cwd=self.dirpath, env=self.gitenv)
 
     def rm(self, filename):
-        cmd = ['git', 'rm', filename]
+        cmd = ['git', 'rm', '-f', filename]
         self._exec(cmd, cwd=self.dirpath, env=self.gitenv)
 
     def tag(self, version):

--- a/releases/unreleased/error-removing-release-notes.yml
+++ b/releases/unreleased/error-removing-release-notes.yml
@@ -1,0 +1,8 @@
+---
+title: Error removing changelog entries
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Changelog entries that are processed while doing a release that
+  is not a release candidate were raising a Git error.


### PR DESCRIPTION
This PR forces the removal of changelogs already processed to avoid the error: "the following file has changes staged in the index"