### PR TITLE
[publish] Option to push to a specific branch

### DIFF
--- a/release_tools/publish.py
+++ b/release_tools/publish.py
@@ -46,7 +46,9 @@ from release_tools.repo import RepositoryError
               help="Do not generate a release commit; push the existing one.")
 @click.option('--no-cleanup', is_flag=True,
               help="Do not remove changelog entries from the repository.")
-def publish(version, author, remote, only_push, no_cleanup):
+@click.option('--remote-branch', 'remote_branch', default="master",
+              help="Remote branch to push. Default 'master'.")
+def publish(version, author, remote, only_push, no_cleanup, remote_branch):
     """Publish a new release.
 
     This script will generate a new release in the repository.
@@ -62,6 +64,9 @@ def publish(version, author, remote, only_push, no_cleanup):
 
     It is also possible to push only the commit release and its tag.
     To do so, set '--only-push' together with '--push' option.
+
+    To push into a different branch than `master` use the
+    `--remote-branch' option.
 
     When '--no-cleanup' argument is specified, do not remove changelog
     entries.
@@ -87,7 +92,7 @@ def publish(version, author, remote, only_push, no_cleanup):
             commit(project, version, author)
 
         if remote:
-            push(project, remote, version)
+            push(project, remote, version, remote_branch)
     except RepositoryError as e:
         raise click.ClickException(e)
 
@@ -202,12 +207,12 @@ def commit(project, version, author):
     click.echo("done")
 
 
-def push(project, remote, release_tag):
+def push(project, remote, release_tag, branch="master"):
     """Publish the release in the given remote repository."""
 
     click.echo("Publishing release in {}...".format(remote), nl=False)
 
-    project.repo.push(remote, 'master')
+    project.repo.push(remote, branch)
     project.repo.push(remote, release_tag)
 
     click.echo("done")

--- a/releases/unreleased/option-to-include-branch-in-publish.yml
+++ b/releases/unreleased/option-to-include-branch-in-publish.yml
@@ -1,0 +1,8 @@
+---
+title: Option to include branch in `publish` command
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Include the `--remote-branch <branch>` option in `publish` to push
+  to a specific remote branch. By default it is `master`.

--- a/tests/test_publish.py
+++ b/tests/test_publish.py
@@ -688,6 +688,24 @@ class TestPublish(unittest.TestCase):
             # Push method was not called
             mock_project.return_value.repo.push.assert_not_called()
 
+    @unittest.mock.patch('release_tools.publish.Project')
+    def test_publish_different_branch(self, mock_project):
+        """Test when '--remote-branch' is defined with a branch different from master."""
+
+        runner = click.testing.CliRunner()
+
+        with runner.isolated_filesystem() as fs:
+            # Run the command
+            result = runner.invoke(publish.publish,
+                                   ["--push", "myremote", "--only-push",
+                                    "--remote-branch", "main",
+                                    "0.8.10", "John Smith <jsmith@example.org>"])
+            self.assertEqual(result.exit_code, 0)
+
+            # Commit and the tag were pushed and branch main
+            mock_project.return_value.repo.push.assert_any_call('myremote', 'main')
+            mock_project.return_value.repo.push.assert_any_call('myremote', '0.8.10')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Include the `--remote-branch <branch>` option in `publish` to push to a specific remote branch. By default it is `master`.