### PR TITLE
Fix release workflow including token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           gh release create ${{ steps.tag.outputs.tag }} -t ${{ steps.tag.outputs.tag }} -F ./releases/${{ steps.tag.outputs.tag }}.md
         env:
-          GITHUB_TOKEN: ${{ inputs.github-token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish:
     needs: [release]


### PR DESCRIPTION
This PR replaces a typo in the workflow that was using input instead of secrets.